### PR TITLE
fix: resolve status filtering and due date parsing bugs

### DIFF
--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -75,13 +75,15 @@ def parse_tasks(content: str) -> dict:
                     if current_task not in result['due_today']:
                         result['due_today'].append(current_task)
                 else:
-                    # Try to parse date
-                    for fmt in ['%Y-%m-%d', 'Before %B %d', 'Before %b %d']:
+                    # Try to parse date - strip "Before" prefix first
+                    date_str = due_str
+                    if due_str.lower().startswith('before '):
+                        date_str = due_str[7:].strip()  # Remove "Before " prefix
+                    
+                    # Try various formats (full and abbreviated month names)
+                    for fmt in ['%Y-%m-%d', '%B %d', '%b %d']:
                         try:
-                            if fmt.startswith('Before'):
-                                due_date = datetime.strptime(due_str, fmt).date()
-                            else:
-                                due_date = datetime.strptime(due_str.split()[0], '%Y-%m-%d').date()
+                            due_date = datetime.strptime(date_str, fmt).date()
                             if due_date.year == 1900:
                                 due_date = due_date.replace(year=today.year)
                             


### PR DESCRIPTION
## Summary

Fixes two bugs identified in the initial code review:

### Issue #1: Status filtering mismatch
- **Problem:** CLI `--status in-progress` never matched stored `Status: In Progress`
- **Fix:** Normalize by replacing hyphens with spaces before comparison
- **Files:** `scripts/tasks.py`

### Issue #2: Due date parsing fails on "Before" prefix
- **Problem:** Dates like "Before Jan 29" failed to parse because `split()[0]` returned "Before"
- **Fix:** Strip "Before " prefix before parsing, handle both full (January) and abbreviated (Jan) month formats
- **Files:** `scripts/tasks.py`, `scripts/standup.py`

## Testing

Both issues tested with:
- `tasks.py list --status in-progress` now matches tasks with `Status: In Progress`
- `tasks.py list --due today` correctly includes tasks due "Before Jan 29"

---

Closes #1, #2
