### PR TITLE
feat: improve error handling for missing TASKS.md

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Initialize Task Tracker - Create TASKS.md from template.
+"""
+
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).parent.parent
+TEMPLATE_FILE = SKILL_DIR / "assets" / "templates" / "TASKS.md"
+TARGET_FILE = Path.home() / "clawd" / "memory" / "work" / "TASKS.md"
+
+
+def init():
+    """Create TASKS.md from template."""
+    if TARGET_FILE.exists():
+        print(f"\n⚠️ Tasks file already exists: {TARGET_FILE}")
+        print("Delete it first if you want to recreate from template.\n")
+        sys.exit(1)
+    
+    if not TEMPLATE_FILE.exists():
+        print(f"\n❌ Template not found: {TEMPLATE_FILE}")
+        sys.exit(1)
+    
+    # Ensure directory exists
+    TARGET_FILE.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Copy template
+    content = TEMPLATE_FILE.read_text()
+    TARGET_FILE.write_text(content)
+    
+    print(f"\n✅ Created tasks file: {TARGET_FILE}\n")
+    print("Next steps:")
+    print("  python3 scripts/tasks.py list\n")
+
+
+if __name__ == '__main__':
+    init()

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -106,7 +106,9 @@ def parse_tasks(content: str) -> dict:
 def generate_standup(date_str: str = None) -> str:
     """Generate daily standup summary."""
     if not TASKS_FILE.exists():
-        return f"❌ Tasks file not found: {TASKS_FILE}"
+        return (f"❌ Tasks file not found: {TASKS_FILE}\n\n"
+                f"To create a new tasks file, run:\n"
+                f"  python3 {Path(__file__).parent / 'init.py'}\n")
     
     content = TASKS_FILE.read_text()
     tasks = parse_tasks(content)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -84,7 +84,11 @@ def parse_tasks(content: str) -> list[dict]:
 def load_tasks() -> tuple[str, list[dict]]:
     """Load and parse tasks from file."""
     if not TASKS_FILE.exists():
-        print(f"Tasks file not found: {TASKS_FILE}", file=sys.stderr)
+        print(f"\n❌ Tasks file not found: {TASKS_FILE}\n", file=sys.stderr)
+        print("To create a new tasks file, run:")
+        print(f"  cp {Path(__file__).parent.parent / 'assets' / 'templates' / 'TASKS.md'} {TASKS_FILE}")
+        print(f"\nOr create from template:")
+        print(f"  python3 scripts/init.py\n")
         sys.exit(1)
     
     content = TASKS_FILE.read_text()

--- a/scripts/weekly_review.py
+++ b/scripts/weekly_review.py
@@ -129,7 +129,9 @@ def archive_done_tasks(content: str, done_tasks: list) -> str:
 def generate_weekly_review(archive: bool = False) -> str:
     """Generate weekly review summary."""
     if not TASKS_FILE.exists():
-        return f"❌ Tasks file not found: {TASKS_FILE}"
+        return (f"❌ Tasks file not found: {TASKS_FILE}\n\n"
+                f"To create a new tasks file, run:\n"
+                f"  python3 {Path(__file__).parent / 'init.py'}\n")
     
     content = TASKS_FILE.read_text()
     tasks = parse_tasks(content)


### PR DESCRIPTION
## Summary

Improves error handling when TASKS.md is missing and provides helpful guidance.

### Changes

1. **Enhanced error messages** - All scripts now show:
   - Clear error message with file path
   - Instructions to create the file
   - Command to run init.py

2. **New init.py script** - Creates TASKS.md from template:
   ```bash
   python3 scripts/init.py
   ```

3. **Updated scripts:**
   - `tasks.py` - Full error with copy command
   - `standup.py` - Inline error with init.py command
   - `weekly_review.py` - Inline error with init.py command

### Before
```
$ tasks.py list
Tasks file not found: /home/user/clawd/memory/work/TASKS.md
```

### After
```
$ tasks.py list
❌ Tasks file not found: /home/user/clawd/memory/work/TASKS.md

To create a new tasks file, run:
  cp /home/user/clawd/skills/task-tracker/assets/templates/TASKS.md /home/user/clawd/memory/work/TASKS.md

Or create from template:
  python3 scripts/init.py
```

---

Closes #6
