### PR TITLE
feat: bucket missed tasks by age

### DIFF
--- a/scripts/personal_standup.py
+++ b/scripts/personal_standup.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 # Add parent directory to path for utils import
 sys.path.insert(0, str(Path(__file__).parent))
-from utils import load_tasks, check_due_date, get_section_display_name, get_missed_tasks
+from utils import load_tasks, check_due_date, get_section_display_name, get_missed_tasks, get_missed_tasks_bucketed
 
 
 def get_calendar_events() -> dict:
@@ -196,9 +196,9 @@ def main():
     args = parser.parse_args()
     
     _, tasks_data = load_tasks(personal=True)
-    missed_tasks = []
+    missed_buckets = None
     if not args.skip_missed:
-        missed_tasks = get_missed_tasks(tasks_data, reference_date=args.date)
+        missed_buckets = get_missed_tasks_bucketed(tasks_data, reference_date=args.date)
 
     result = generate_personal_standup(
         date_str=args.date,
@@ -207,14 +207,42 @@ def main():
     )
 
     missed_block = ""
-    if missed_tasks and not args.json:
-        missed_lines = ["🔴 **Missed (due yesterday):**"]
-        for task in missed_tasks:
-            title = task.get('title', '')
-            missed_lines.append(f"  • {title} — say \"done {title}\" to mark complete")
-        missed_lines.append("")
-        missed_block = "\n".join(missed_lines)
-        result = f"{missed_block}{result}"
+    if missed_buckets and not args.json:
+        has_missed = any(missed_buckets.get(k) for k in ['yesterday', 'last7', 'last30', 'older'])
+        if has_missed:
+            missed_lines = ["🔴 **Missed Tasks:**"]
+            
+            # Yesterday
+            if missed_buckets.get('yesterday'):
+                missed_lines.append("\n  **Yesterday:**")
+                for task in missed_buckets['yesterday']:
+                    title = task.get('title', '')
+                    missed_lines.append(f"    • {title} — say \"done {title}\" to mark complete")
+            
+            # Last 7 days (excluding yesterday)
+            if missed_buckets.get('last7'):
+                missed_lines.append("\n  **Last 7 Days:**")
+                for task in missed_buckets['last7']:
+                    title = task.get('title', '')
+                    missed_lines.append(f"    • {title}")
+            
+            # Last 30 days
+            if missed_buckets.get('last30'):
+                missed_lines.append("\n  **Last 30 Days:**")
+                for task in missed_buckets['last30']:
+                    title = task.get('title', '')
+                    missed_lines.append(f"    • {title}")
+            
+            # Older than 30 days
+            if missed_buckets.get('older'):
+                missed_lines.append("\n  **Older than 30 Days:**")
+                for task in missed_buckets['older']:
+                    title = task.get('title', '')
+                    missed_lines.append(f"    • {title}")
+            
+            missed_lines.append("")
+            missed_block = "\n".join(missed_lines)
+            result = f"{missed_block}{result}"
     
     if args.json:
         print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary

Buckets missed tasks by age instead of only showing yesterday's misses.

## Changes

- **utils.py**: Add `get_missed_tasks_bucketed()` function with 4 buckets:
  - `yesterday` — tasks due yesterday (shows "done" action prompt)
  - `last7` — tasks due 2-7 days ago
  - `last30` — tasks due 8-30 days ago
  - `older` — tasks due >30 days ago

- **standup.py**: Updated to display bucketed missed tasks
- **personal_standup.py**: Same updates for personal standup

## Example Output

```
🔴 **Missed Tasks:**

  **Yesterday:**
    • Task due yesterday — say "done {title}" to mark complete

  **Last 7 Days:**
    • Task from 3 days ago

  **Last 30 Days:**
    • Check with Haven about Q4 2025 financials
    • 1099s process (Haven)

  **Older than 30 Days:**
    • Ancient overdue task
```

## Fixes

Follow-up to #22 — previous implementation only showed tasks due yesterday, which was empty when all overdue tasks were older.

## Testing

- [x] Local test shows 11 overdue tasks correctly bucketed in "Last 30 Days"
- [x] `--skip-missed` flag still works
- [x] `--date` flag still works for backdating
- [x] Personal standup updated

---

Ready for review!