### PR TITLE
fix: extract_tasks.py @mention parsing and --blocks removal (#27)

### DIFF
--- a/scripts/extract_tasks.py
+++ b/scripts/extract_tasks.py
@@ -18,12 +18,12 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 # Regex patterns for common meeting note formats
 TASK_PATTERNS = [
-    # Assignee pattern with checkbox: "- [ ] @person: Task" (highest priority)
-    (r'-\s*\[\s*\]\s*@([\w.-]+):\s*(.+?)$', 'medium'),
-    # Assignee pattern: "@person: Task" or "- @person: Task"
-    (r'@([\w.-]+):\s*(.+?)$', 'medium'),
-    # Markdown checkbox: "- [ ] Task" or "- [x] Task"
-    (r'-\s*\[\s*\]\s*(.+?)$', 'medium'),
+    # Assignee pattern with checkbox: "- [ ] @person: Task" (highest priority, unchecked only)
+    (r'^\s*-\s*\[\s*\]\s*@([\w-]+):\s*(.+?)$', 'medium'),
+    # Assignee pattern: "@person: Task" or "- @person: Task" (line start only)
+    (r'^\s*-?\s*@([\w-]+):\s*(.+?)$', 'medium'),
+    # Markdown checkbox: "- [ ] Task" (unchecked only)
+    (r'^\s*-\s*\[\s*\]\s*(.+?)$', 'medium'),
     # TODO marker: "TODO: Task" or "- TODO: Task"
     (r'(?:^-?\s*)?TODO:\s*(.+?)$', 'medium'),
     # Action marker: "Action: Task" or "- Action: Task"


### PR DESCRIPTION
Fixes #27

## Changes

### Bug 1: @person pattern extracted person name as title
**Before**: `@sarah: ship release` → title=`sarah`, owner=`martin`  
**After**: `@sarah: ship release` → title=`ship release`, owner=`sarah`

Fixed by checking regex capture group count (`match.lastindex >= 2`) and mapping:
- group(1) → owner
- group(2) → title

### Bug 2: Generated commands included --blocks flag
**Before**: `tasks.py add "Task" --blocks "..."` (tasks.py doesn't support --blocks)  
**After**: `tasks.py add "Task"` (removed --blocks entirely)

## Testing
```bash
python3 scripts/extract_tasks.py --from-text '@sarah: ship release'
# Output: tasks.py add "ship release" --owner sarah
```

## Review
- Codex reviewed: 0 P0-P2 issues
- Only modified `scripts/extract_tasks.py` (no other files touched)
- All other task patterns (TODO, checkboxes) continue to work correctly

Closes #27
