### PR TITLE
chore: narrow bare except in standup_common.py (#39)

### DIFF
--- a/scripts/standup_common.py
+++ b/scripts/standup_common.py
@@ -83,7 +83,7 @@ def format_time(iso_time: str) -> str:
     try:
         dt = datetime.fromisoformat(iso_time.replace("Z", "+00:00"))
         return dt.strftime("%I:%M %p").lstrip("0")
-    except Exception:
+    except (ValueError, TypeError):
         return iso_time
 
 


### PR DESCRIPTION
Closes #39

The original unused imports and bare `except:` clauses from #39 were already resolved by PR #42 (standup refactor). The only remaining item was `except Exception:` in `format_time()` which should catch `(ValueError, TypeError)` specifically.

Note: All unused imports checked via AST analysis — all clean after the refactor.