### PR TITLE
feat: add Lessons Learned section to weekly review (#38)

### DIFF
--- a/scripts/weekly_review.py
+++ b/scripts/weekly_review.py
@@ -157,9 +157,15 @@ def extract_lessons(notes_dir: Path, start_date: date, end_date: date) -> list[s
         if note_date < start_date or note_date > end_date:
             continue
 
-        for raw_line in notes_file.read_text().splitlines():
+        try:
+            content = notes_file.read_text()
+        except (PermissionError, UnicodeDecodeError, OSError):
+            # Skip unreadable or non-UTF8 files silently
+            continue
+
+        for raw_line in content.splitlines():
             line = raw_line.strip()
-            match_line = re.search(r"(?:lesson|insight)::\s*(.+)", line, flags=re.IGNORECASE)
+            match_line = re.search(r"\b(?:lesson|insight)::\s*(.+)", line, flags=re.IGNORECASE)
             if match_line:
                 lessons.append(match_line.group(1).strip())
 


### PR DESCRIPTION
Closes #38

## Changes
- Added `TASK_TRACKER_DAILY_NOTES_DIR` environment variable to configure daily notes directory
- Added `extract_lessons()` helper function to scan daily notes (YYYY-MM-DD.md) for `lesson::` and `insight::` tags
- Added "📝 Lessons & Insights" section at end of weekly review output
- If lessons found: displays bullet list
- If no lessons or no notes dir configured: displays reflection prompt

## Testing
- Validated edge cases: missing dir, empty dir, malformed date filenames
- Confirmed existing behavior unchanged
- Tested with and without `TASK_TRACKER_DAILY_NOTES_DIR` set

## Implementation Notes
- Only modified `scripts/weekly_review.py` as required
- Used regex for case-insensitive tag matching
- Properly handles date range filtering
- Graceful fallback when notes unavailable