### PR TITLE
feat: task dependencies and sprint grouping (#55, #56)

### DIFF
--- a/scripts/personal_standup.py
+++ b/scripts/personal_standup.py
@@ -25,6 +25,8 @@ from utils import (
     recurrence_suffix,
     parse_duration,
     format_duration,
+    dependency_suffix,
+    sprint_suffix,
 )
 
 
@@ -69,7 +71,9 @@ def format_personal_standup(output: dict, date_display: str) -> str:
             esc = escalation_suffix(t)
             rec = recurrence_suffix(t)
             est = f" ({t['estimate']})" if t.get('estimate') else ""
-            lines.append(f"  • {t['title']}{esc}{rec}{est}")
+            dep = dependency_suffix(t)
+            spr = sprint_suffix(t)
+            lines.append(f"  • {t['title']}{esc}{rec}{est}{dep}{spr}")
         lines.append("")
     
     # Q2 Should Do
@@ -81,7 +85,9 @@ def format_personal_standup(output: dict, date_display: str) -> str:
             due_str = f" (🗓️{t['due']})" if t.get('due') else ""
             rec = recurrence_suffix(t)
             est = f" ({t['estimate']})" if t.get('estimate') else ""
-            lines.append(f"  • {t['title']}{due_str}{rec}{est}")
+            dep = dependency_suffix(t)
+            spr = sprint_suffix(t)
+            lines.append(f"  • {t['title']}{due_str}{rec}{est}{dep}{spr}")
         lines.append("")
     
     # Q3 Waiting On
@@ -90,7 +96,8 @@ def format_personal_standup(output: dict, date_display: str) -> str:
         for t in output['q3']:
             esc = escalation_suffix(t)
             rec = recurrence_suffix(t)
-            lines.append(f"  • {t['title']}{esc}{rec}")
+            dep = dependency_suffix(t)
+            lines.append(f"  • {t['title']}{esc}{rec}{dep}")
         lines.append("")
     
     # Completed

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -27,6 +27,8 @@ from utils import (
     recurrence_suffix,
     parse_duration,
     format_duration,
+    dependency_suffix,
+    sprint_suffix,
 )
 
 
@@ -254,7 +256,9 @@ def generate_standup(
                 esc = escalation_suffix(t)
                 rec = recurrence_suffix(t)
                 est = f" ({t['estimate']})" if t.get('estimate') else ""
-                lines.append(f"    • {t['title']}{esc}{rec}{est}")
+                dep = dependency_suffix(t)
+                spr = sprint_suffix(t)
+                lines.append(f"    • {t['title']}{esc}{rec}{est}{dep}{spr}")
         lines.append("")
     
     # Q2 - Important, Not Urgent
@@ -269,7 +273,9 @@ def generate_standup(
                 due_str = f" (🗓️{t['due']})" if t.get('due') else ""
                 rec = recurrence_suffix(t)
                 est = f" ({t['estimate']})" if t.get('estimate') else ""
-                lines.append(f"    • {t['title']}{due_str}{rec}{est}")
+                dep = dependency_suffix(t)
+                spr = sprint_suffix(t)
+                lines.append(f"    • {t['title']}{due_str}{rec}{est}{dep}{spr}")
         lines.append("")
     
     # Q3 - Waiting/Blocked
@@ -279,7 +285,8 @@ def generate_standup(
             blocks_str = f" → {t['blocks']}" if t.get('blocks') else ""
             esc = escalation_suffix(t)
             rec = recurrence_suffix(t)
-            lines.append(f"  • {t['title']}{blocks_str}{esc}{rec}")
+            dep = dependency_suffix(t)
+            lines.append(f"  • {t['title']}{blocks_str}{esc}{rec}{dep}")
         lines.append("")
     
     # Team tasks

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -161,6 +161,8 @@ def parse_tasks(content: str, personal: bool = False, format: str = 'obsidian') 
             task_type = None
             recur = None
             estimate = None
+            depends = None
+            sprint = None
             
             if format == 'obsidian':
                 # Parse emoji date
@@ -197,6 +199,14 @@ def parse_tasks(content: str, personal: bool = False, format: str = 'obsidian') 
                 estimate_match = re.search(r'(?<!\w)estimate::\s*(?!(\s|\w+::))([^\n]+?)(?=\s+\w+::|\s*🗓️|$)', rest)
                 if estimate_match:
                     estimate = estimate_match.group(2).strip()
+
+                depends_match = re.search(r'(?<!\w)depends::\s*(?!(\s|\w+::))([^\n]+?)(?=\s+\w+::|\s*🗓️|$)', rest)
+                if depends_match:
+                    depends = depends_match.group(2).strip()
+
+                sprint_match = re.search(r'(?<!\w)sprint::\s*(?!(\s|\w+::))([^\n]+?)(?=\s+\w+::|\s*🗓️|$)', rest)
+                if sprint_match:
+                    sprint = sprint_match.group(2).strip()
             
             current_task = {
                 'title': title,
@@ -210,6 +220,8 @@ def parse_tasks(content: str, personal: bool = False, format: str = 'obsidian') 
                 'type': task_type,
                 'recur': recur,
                 'estimate': estimate,
+                'depends': depends,
+                'sprint': sprint,
                 'completed_date': completed_date,
                 'raw_line': line,
             }
@@ -621,6 +633,18 @@ def recurrence_suffix(task: dict) -> str:
     """Return recurrence indicator suffix for a task, if any."""
     recur = (task.get('recur') or '').strip()
     return f" 🔄 {recur}" if recur else ""
+
+
+def dependency_suffix(task: dict) -> str:
+    """Return dependency indicator suffix for a task, if any."""
+    depends = (task.get('depends') or '').strip()
+    return f" 🔗 depends: {depends}" if depends else ""
+
+
+def sprint_suffix(task: dict) -> str:
+    """Return sprint indicator suffix for a task, if any."""
+    sprint = (task.get('sprint') or '').strip()
+    return f" 🏃 {sprint}" if sprint else ""
 
 
 def get_section_display_name(section: str, personal: bool = False) -> str:


### PR DESCRIPTION
Closes #55
Closes #56

## Changes
- **utils.py**: Parse `depends::` and `sprint::` inline fields with same regex pattern as other fields. Add `dependency_suffix()` and `sprint_suffix()` helpers.
- **standup.py**: Show 🔗 and 🏃 indicators on Q1/Q2/Q3 task lines.
- **personal_standup.py**: Same treatment.