### PR TITLE
fix: remove hardcoded personal identity from code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Tasks are stored in `~/clawd/memory/work/TASKS.md` using this format:
 ## 🔴 High Priority (This Week)
 
 - [ ] **Task title** — Brief description
-  - Owner: martin
+  - Owner: sarah
   - Due: 2026-01-29
   - Status: Todo
   - Blocks: teammate (reason)
@@ -105,7 +105,7 @@ python3 scripts/tasks.py list --priority high          # High priority only
 python3 scripts/tasks.py list --status done            # Completed tasks
 python3 scripts/tasks.py list --due today              # Due today
 python3 scripts/tasks.py list --due this-week          # Due this week
-python3 scripts/tasks.py list --owner martin           # My tasks
+python3 scripts/tasks.py list --owner your-name           # My tasks
 python3 scripts/tasks.py list --completed-since 24h    # Done last 24h
 python3 scripts/tasks.py list --completed-since 7d     # Done last week
 ```
@@ -115,7 +115,7 @@ python3 scripts/tasks.py list --completed-since 7d     # Done last week
 python3 scripts/tasks.py add "Task description" \
   --priority high \
   --due 2026-01-29 \
-  --owner martin \
+  --owner your-name \
   --blocks "teammate"
 ```
 

--- a/references/task-format.md
+++ b/references/task-format.md
@@ -4,7 +4,7 @@
 
 ```markdown
 - [ ] **Task title** — Brief description
-  - Owner: martin
+  - Owner: your-name
   - Due: 2026-01-29
   - Status: Todo
   - Blocks: lilla (podcast outreach)
@@ -17,7 +17,7 @@
 |-------|----------|-------------|
 | title | Yes | Brief, actionable (verb + noun) |
 | description | No | Additional context after `—` |
-| Owner | No | Person responsible (default: martin) |
+| Owner | No | Person responsible (default: configurable via TASK_TRACKER_DEFAULT_OWNER) |
 | Due | No | ASAP, YYYY-MM-DD, or "Before [event]" |
 | Status | No | Todo, In Progress, Blocked, Waiting, Done |
 | Blocks | No | Who/what is blocked + reason |
@@ -62,7 +62,7 @@
 ### High Priority (Blocking)
 ```markdown
 - [ ] **Set up Apollo.io access for Lilla** — Restore account for email finding
-  - Owner: Martin
+  - Owner: Sarah
   - Due: ASAP
   - Status: Todo
   - Blocks: Lilla (podcast outreach sequence)
@@ -71,7 +71,7 @@
 ### High Priority (Deadline)
 ```markdown
 - [ ] **Create IMCAS lead capture form** — Signup form + ActiveCampaign sequence
-  - Owner: Martin
+  - Owner: Sarah
   - Due: Before Jan 29
   - Status: Todo
   - Location: https://bysha.pe/imcas
@@ -80,7 +80,7 @@
 ### Medium Priority (Review)
 ```markdown
 - [ ] **Review Q1 promo designs** — Identify which need carousel versions
-  - Owner: Martin
+  - Owner: Sarah
   - Status: Todo
   - Location: https://dropbox.com/...
 ```
@@ -95,6 +95,6 @@
 ### Completed
 ```markdown
 - [x] **Ship IMCAS materials to France** — Completed Friday
-  - Owner: Martin
+  - Owner: Sarah
   - Status: Done
 ```

--- a/scripts/extract_tasks.py
+++ b/scripts/extract_tasks.py
@@ -9,12 +9,16 @@ This script can:
 """
 
 import argparse
+import os
 import re
 import shlex
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+
+# Default owner for extracted tasks — override with TASK_TRACKER_DEFAULT_OWNER env var
+DEFAULT_OWNER = os.getenv('TASK_TRACKER_DEFAULT_OWNER', 'me')
 
 # Regex patterns for common meeting note formats
 TASK_PATTERNS = [
@@ -48,7 +52,7 @@ def extract_tasks_local(text: str) -> list[dict]:
         for pattern, default_priority in TASK_PATTERNS:
             match = re.search(pattern, line, re.IGNORECASE)
             if match:
-                owner = 'martin'
+                owner = DEFAULT_OWNER
                 # Assignee pattern captures owner first, then task title.
                 if match.lastindex and match.lastindex >= 2:
                     owner = match.group(1).strip()
@@ -81,7 +85,7 @@ def format_task_command(task: dict) -> str:
     if task.get('priority') and task['priority'] != 'medium':
         parts.extend(['--priority', task['priority']])
     
-    if task.get('owner') and task['owner'] != 'martin':
+    if task.get('owner') and task['owner'] != DEFAULT_OWNER:
         parts.extend(['--owner', task['owner']])
     
     if task.get('due'):
@@ -98,7 +102,7 @@ For each task, determine:
 - title: Brief, actionable title (verb + noun)
 - priority: high (blocking/deadline/revenue), medium (important), low (nice-to-have)
 - due: Date if mentioned, ASAP if urgent, or leave blank
-- owner: Person responsible (default: martin)
+- owner: Person responsible (default: {DEFAULT_OWNER})
 - blocks: Who/what is blocked if this isn't done
 
 Meeting Notes:

--- a/scripts/task-shortcuts.sh
+++ b/scripts/task-shortcuts.sh
@@ -38,7 +38,7 @@ case "${1:-}" in
       exit 0
     fi
 
-    # Print each message with separator that Niemand can parse
+    # Print each message with separator that the agent can parse
     for msg_file in "$_tmpdir/msg_"*; do
       [ -s "$msg_file" ] || continue
       cat "$msg_file"

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import sys
 from datetime import datetime, timedelta
@@ -127,7 +128,8 @@ def add_task(args):
         task_line += f' 🗓️{args.due}'
     if args.area:
         task_line += f' area:: {args.area}'
-    if args.owner and args.owner not in ('me', 'martin'):
+    default_owner = os.getenv('TASK_TRACKER_DEFAULT_OWNER', 'me')
+    if args.owner and args.owner not in ('me', default_owner):
         task_line += f' owner:: {args.owner}'
     
     # Find section and insert after header


### PR DESCRIPTION
Makes the skill community-ready by removing all hardcoded personal references.

## Changes
- **extract_tasks.py**: Default owner now comes from `TASK_TRACKER_DEFAULT_OWNER` env var (defaults to 'me')
- **tasks.py**: Same env var for owner filter logic
- **task-shortcuts.sh**: Generic comment instead of agent-specific name
- **README.md / references/task-format.md**: Generic example names instead of personal ones

No functional changes — just configurability.