### PR TITLE
feat(daily_notes): strip completion timestamps from extracted titles

### DIFF
--- a/scripts/daily_notes.py
+++ b/scripts/daily_notes.py
@@ -35,7 +35,9 @@ def _clean_action_line(line: str) -> str:
     cleaned = re.sub(r"^(?:\[[xX]\]\s*)*", "", cleaned)
     cleaned = re.sub(r"^(?:✅\s*)*", "", cleaned)
     cleaned = re.sub(r"^\s*(?:[-*+•]\s*)*", "", cleaned)
-    return cleaned.strip()
+    cleaned = re.sub(r"(?:\s*-\s*\[[ xX]\]\s*)+$", "", cleaned)
+    cleaned = re.sub(r"\s*✅\s*\d{4}-\d{2}-\d{2}\s*$", "", cleaned)
+    return cleaned.rstrip()
 
 
 def _is_completed_action_line(line: str) -> bool:

--- a/tests/test_daily_notes.py
+++ b/tests/test_daily_notes.py
@@ -1,0 +1,59 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from daily_notes import _clean_action_line, extract_completed_tasks
+
+
+def test_clean_action_line_strips_done_date_stamp():
+    line = "- [x] Review Fizzi leads ✅ 2026-02-11"
+    assert _clean_action_line(line) == "Review Fizzi leads"
+
+
+def test_clean_action_line_strips_trailing_checkbox_artifacts():
+    line = "- [x] Review Fizzi leads ✅ 2026-02-11- [X]   "
+    assert _clean_action_line(line) == "Review Fizzi leads"
+
+
+def test_extract_completed_tasks_returns_clean_titles(tmp_path):
+    note = tmp_path / "2026-02-11.md"
+    note.write_text(
+        "- [x] Review Fizzi leads ✅ 2026-02-11\n"
+        "- [x] Fix parser ✅ 2026-02-11- [ ]\n"
+        "- [ ] Leave unchanged\n"
+    )
+
+    tasks = extract_completed_tasks(
+        notes_dir=tmp_path,
+        start_date=date(2026, 2, 11),
+        end_date=date(2026, 2, 11),
+    )
+
+    assert [task["title"] for task in tasks] == [
+        "Review Fizzi leads",
+        "Fix parser",
+    ]
+
+
+def test_extract_completed_tasks_deduplicates_by_title_and_date(tmp_path):
+    (tmp_path / "2026-02-11.md").write_text(
+        "- [x] Ship release ✅ 2026-02-11\n"
+        "- [x] ship release ✅ 2026-02-11\n"
+        "- [x] Ship release ✅ 2026-02-11- [x]\n"
+    )
+    (tmp_path / "2026-02-12.md").write_text(
+        "- [x] Ship release ✅ 2026-02-12\n"
+    )
+
+    tasks = extract_completed_tasks(
+        notes_dir=tmp_path,
+        start_date=date(2026, 2, 11),
+        end_date=date(2026, 2, 12),
+    )
+
+    assert [(task["title"], task["completed_date"]) for task in tasks] == [
+        ("Ship release", "2026-02-11"),
+        ("Ship release", "2026-02-12"),
+    ]


### PR DESCRIPTION
## Problem

When `done24h` extracts completed tasks from daily notes, titles contain raw completion markers:
- `Review Fizzi leads ✅ 2026-02-11` instead of `Review Fizzi leads`
- `Also talked with Alex ✅ 2026-02-11- [ ]` (malformed trailing checkbox)

## Fix

Updated `_clean_action_line()` in `daily_notes.py` to strip:
1. Trailing `✅ YYYY-MM-DD` date stamps
2. Trailing `- [ ]` / `- [x]` checkbox artifacts
3. Trailing whitespace after cleanup

## Tests

Added `tests/test_daily_notes.py` with 4 focused pytest tests:
- Date stamp stripping
- Trailing checkbox artifact stripping
- Clean titles from `extract_completed_tasks` (with temp daily note dir)
- Deduplication: same-date dedupes, cross-date retains

All 4 tests pass.

## Related

Part of [lobster-workflows#53](https://github.com/kesslerio/lobster-workflows/issues/53) — fixing the broken Daily Work Standup cron.

## Verified

```
TASK_TRACKER_DAILY_NOTES_DIR=/home/art/Obsidian/06-Daily python3 scripts/tasks.py list --status done --completed-since 24h
```
Now returns clean titles (19 items from Feb 11 daily note).