### PR TITLE
feat(tasks): parking lot operations (#72)

### DIFF
--- a/scripts/parking_lot.py
+++ b/scripts/parking_lot.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Parking Lot (backlog) operations for the task tracker.
+
+Manages the 🅿️ Parking Lot section in the objectives file:
+- list: show items with stale status and count
+- add: add item respecting hard cap
+- stale: list items older than threshold (JSON)
+- promote: move item to objectives section
+- drop: remove item and archive as "dropped"
+"""
+
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, date
+from pathlib import Path
+
+
+def _parking_lot_cap() -> int:
+    return int(os.getenv('PARKING_LOT_CAP', '25'))
+
+
+def _parking_lot_stale_days() -> int:
+    return int(os.getenv('PARKING_LOT_STALE_DAYS', '30'))
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content atomically via tempfile + rename."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix='.tmp')
+    try:
+        os.write(fd, content.encode())
+        os.close(fd)
+        fd = -1
+        os.replace(tmp, path)
+    except Exception:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def _find_parking_lot_bounds(lines: list[str]) -> tuple[int, int]:
+    """Find start (header line) and end (exclusive) of the Parking Lot section.
+
+    Returns (header_index, end_index). end_index points to the next
+    ## header or len(lines).  Returns (-1, -1) if not found.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r'##\s+🅿️\s*Parking Lot\b', line, re.IGNORECASE) or \
+           re.match(r'##\s+Parking Lot\b', line, re.IGNORECASE):
+            start = i
+            break
+    if start is None:
+        return -1, -1
+
+    end = start + 1
+    while end < len(lines):
+        if lines[end].startswith('## '):
+            break
+        end += 1
+    return start, end
+
+
+def _parse_items(lines: list[str], start: int, end: int) -> list[dict]:
+    """Parse task items from the parking lot section lines."""
+    items = []
+    idx = 0
+    for i in range(start + 1, end):
+        line = lines[i]
+        m = re.match(r'^- \[( |x|X)\] (.+)', line)
+        if not m:
+            continue
+        idx += 1
+        done = m.group(1).lower() == 'x'
+        body = m.group(2).strip()
+
+        # Extract created:: date
+        created_match = re.search(r'created::(\S+)', body)
+        created_date = created_match.group(1) if created_match else None
+
+        # Extract stale:: marker
+        stale_match = re.search(r'stale::(\S+)', body)
+        stale_date = stale_match.group(1) if stale_match else None
+
+        # Extract department tags (#Dev, #Sales, etc.)
+        dept_tags = re.findall(r'#([A-Z]\w+)', body)
+        department = dept_tags[0] if dept_tags else None
+
+        # Extract priority tag (#urgent, #high, #medium, #low)
+        priority = None
+        for p in ('urgent', 'high', 'medium', 'low'):
+            if re.search(rf'#{p}\b', body, re.IGNORECASE):
+                priority = p
+                break
+
+        # Clean title: strip bold, inline fields, tags
+        title = body
+        title = re.sub(r'\*\*(.+?)\*\*', r'\1', title)  # strip bold
+        title = re.sub(r'\s*created::\S+', '', title)
+        title = re.sub(r'\s*stale::\S+', '', title)
+        title = re.sub(r'\s*#\w+', '', title)
+        title = title.strip().rstrip('—').strip()
+
+        items.append({
+            'id': idx,
+            'line_num': i,
+            'title': title,
+            'done': done,
+            'created': created_date,
+            'stale': stale_date,
+            'department': department,
+            'priority': priority,
+            'raw_line': line,
+        })
+    return items
+
+
+def _days_since(date_str: str | None) -> int | None:
+    """Return days since a YYYY-MM-DD date string, or None."""
+    if not date_str:
+        return None
+    try:
+        d = datetime.strptime(date_str, '%Y-%m-%d').date()
+        return (date.today() - d).days
+    except ValueError:
+        return None
+
+
+def _is_stale(item: dict) -> bool:
+    """Check if a parking lot item is stale based on created date."""
+    threshold = _parking_lot_stale_days()
+    age = _days_since(item.get('created'))
+    return age is not None and age >= threshold
+
+
+# ── Public API ───────────────────────────────────────────────
+
+
+def list_items(tasks_file: Path) -> str:
+    """List all parking lot items with stale indicators. Returns formatted text."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    if start == -1:
+        return "No Parking Lot section found."
+
+    items = _parse_items(lines, start, end)
+    cap = _parking_lot_cap()
+
+    if not items:
+        return f"Parking Lot is empty. [0/{cap} items]"
+
+    stale_count = sum(1 for it in items if _is_stale(it))
+    result = []
+    for it in items:
+        stale_tag = " — STALE" if _is_stale(it) else ""
+        age = _days_since(it.get('created'))
+        age_str = f" ({age} days)" if age is not None else ""
+        dept = f" #{it['department']}" if it.get('department') else ""
+        pri = f" #{it['priority']}" if it.get('priority') and it['priority'] != 'low' else ""
+        result.append(f"{it['id']}. {it['title']}{dept}{pri}{age_str}{stale_tag}")
+
+    result.append(f"[{len(items)}/{cap} items, {stale_count} stale]")
+    return '\n'.join(result)
+
+
+def list_stale(tasks_file: Path) -> str:
+    """List stale items as JSON (for agent/weekly review consumption)."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    if start == -1:
+        return json.dumps([])
+
+    items = _parse_items(lines, start, end)
+    stale = []
+    for it in items:
+        if _is_stale(it):
+            stale.append({
+                'id': it['id'],
+                'title': it['title'],
+                'department': it.get('department'),
+                'priority': it.get('priority'),
+                'created': it.get('created'),
+                'age_days': _days_since(it.get('created')),
+            })
+    return json.dumps(stale, indent=2)
+
+
+def add_item(tasks_file: Path, title: str, dept: str | None = None,
+             priority: str = 'low') -> str:
+    """Add an item to the parking lot. Returns status message."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+
+    if start == -1:
+        return "❌ No Parking Lot section found in tasks file."
+
+    items = _parse_items(lines, start, end)
+    cap = _parking_lot_cap()
+    if len(items) >= cap:
+        return f"❌ Parking lot full ({len(items)}/{cap}). Drop an item first."
+
+    # Build task line
+    today_str = date.today().isoformat()
+    task_line = f'- [ ] **{title}**'
+    if dept:
+        task_line += f' #{dept}'
+    if priority and priority != 'low':
+        task_line += f' #{priority}'
+    task_line += f' created::{today_str}'
+
+    # Insert after last existing item, or right after header+blank
+    insert_at = start + 1
+    for i in range(start + 1, end):
+        if re.match(r'^- \[', lines[i]):
+            insert_at = i + 1
+
+    lines.insert(insert_at, task_line)
+    _atomic_write(tasks_file, '\n'.join(lines))
+    return f"✅ Added to Parking Lot: {title} [{len(items) + 1}/{cap}]"
+
+
+def promote_item(tasks_file: Path, item_id: int) -> str:
+    """Move item from parking lot to objectives/high-priority section."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+
+    if start == -1:
+        return "❌ No Parking Lot section found."
+
+    items = _parse_items(lines, start, end)
+    target = next((it for it in items if it['id'] == item_id), None)
+    if not target:
+        return f"❌ Item #{item_id} not found in Parking Lot."
+
+    # Remove from parking lot
+    removed_line = lines.pop(target['line_num'])
+
+    # Clean the line: strip created/stale fields
+    promoted = removed_line
+    promoted = re.sub(r'\s*created::\S+', '', promoted)
+    promoted = re.sub(r'\s*stale::\S+', '', promoted)
+    promoted = promoted.rstrip()
+
+    # Find insertion target: Objectives header > 🔴 header > before parking lot
+    insert_at = None
+    for i, line in enumerate(lines):
+        if re.match(r'##\s+Objectives\b', line, re.IGNORECASE):
+            insert_at = i + 1
+            while insert_at < len(lines) and lines[insert_at].strip() == '':
+                insert_at += 1
+            break
+        if re.match(r'##\s+🔴', line):
+            insert_at = i + 1
+            while insert_at < len(lines) and lines[insert_at].strip() == '':
+                insert_at += 1
+            break
+
+    if insert_at is None:
+        # Fallback: insert right before parking lot header
+        for i, line in enumerate(lines):
+            if re.match(r'##\s+🅿️|##\s+Parking Lot\b', line, re.IGNORECASE):
+                insert_at = i
+                break
+        if insert_at is None:
+            insert_at = len(lines)
+
+    lines.insert(insert_at, promoted)
+    _atomic_write(tasks_file, '\n'.join(lines))
+    return f"✅ Promoted from Parking Lot: {target['title']}"
+
+
+def drop_item(tasks_file: Path, item_id: int,
+              archive_dir: Path | None = None) -> str:
+    """Remove item from parking lot and optionally archive as dropped."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+
+    if start == -1:
+        return "❌ No Parking Lot section found."
+
+    items = _parse_items(lines, start, end)
+    target = next((it for it in items if it['id'] == item_id), None)
+    if not target:
+        return f"❌ Item #{item_id} not found in Parking Lot."
+
+    lines.pop(target['line_num'])
+    _atomic_write(tasks_file, '\n'.join(lines))
+
+    # Append to weekly archive if dir provided
+    if archive_dir:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        today = date.today()
+        week_num = today.isocalendar()[1]
+        archive_file = archive_dir / f"{today.year}-W{week_num:02d}.md"
+
+        if archive_file.exists():
+            arc = archive_file.read_text()
+        else:
+            arc = f"# Done Archive — Week of {today.strftime('%b %d, %Y')} (W{week_num:02d})\n\n"
+
+        dept = target.get('department') or 'Uncategorized'
+        dept_header = f"## {dept}\n"
+        entry = f"- [x] ~~{target['title']}~~ (dropped) ✅ {today.isoformat()}\n"
+
+        if dept_header in arc:
+            idx = arc.index(dept_header) + len(dept_header)
+            arc = arc[:idx] + entry + arc[idx:]
+        else:
+            arc += f"\n{dept_header}{entry}"
+
+        _atomic_write(archive_file, arc)
+
+    return f"✅ Dropped from Parking Lot: {target['title']}"

--- a/tests/test_parking_lot.py
+++ b/tests/test_parking_lot.py
@@ -1,0 +1,180 @@
+"""Tests for parking lot operations."""
+
+import json
+import os
+import tempfile
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+# Allow imports from scripts/
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+from parking_lot import (
+    _find_parking_lot_bounds,
+    _parse_items,
+    _is_stale,
+    list_items,
+    list_stale,
+    add_item,
+    promote_item,
+    drop_item,
+)
+
+
+SAMPLE_CONTENT = """\
+# Weekly Objectives
+
+## Objectives
+
+- [ ] **Launch V2** #Dev #high
+  - [ ] Ship API endpoint
+  - [ ] Write docs
+
+## 🅿️ Parking Lot
+
+- [ ] **Set up webhook integration** #Dev created::2026-01-01
+- [ ] **Review pricing page** #Marketing created::{recent}
+- [ ] **Notion integration research** #Dev #medium created::2025-12-01
+
+## ✅ Done
+
+- [x] **Old task**
+""".replace('{recent}', date.today().isoformat())
+
+
+@pytest.fixture
+def tasks_file(tmp_path):
+    f = tmp_path / 'Work Tasks.md'
+    f.write_text(SAMPLE_CONTENT)
+    return f
+
+
+def test_find_parking_lot_bounds():
+    lines = SAMPLE_CONTENT.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    assert start >= 0
+    assert lines[start].startswith('## 🅿️ Parking Lot')
+    assert end > start
+    # Next section is ## ✅ Done
+    assert lines[end].startswith('## ✅ Done')
+
+
+def test_parse_items():
+    lines = SAMPLE_CONTENT.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    items = _parse_items(lines, start, end)
+    assert len(items) == 3
+    assert items[0]['title'] == 'Set up webhook integration'
+    assert items[0]['department'] == 'Dev'
+    assert items[0]['created'] == '2026-01-01'
+    assert items[1]['title'] == 'Review pricing page'
+    assert items[1]['department'] == 'Marketing'
+    assert items[2]['priority'] == 'medium'
+
+
+def test_is_stale():
+    old_date = (date.today() - timedelta(days=45)).isoformat()
+    recent_date = date.today().isoformat()
+    assert _is_stale({'created': old_date}) is True
+    assert _is_stale({'created': recent_date}) is False
+    assert _is_stale({}) is False
+
+
+def test_list_items(tasks_file):
+    output = list_items(tasks_file)
+    assert '1. Set up webhook integration' in output
+    assert '2. Review pricing page' in output
+    assert '3. Notion integration research' in output
+    assert '/25 items' in output
+    assert 'STALE' in output  # old items should be marked stale
+
+
+def test_list_stale(tasks_file):
+    result = json.loads(list_stale(tasks_file))
+    # At least the 2026-01-01 and 2025-12-01 items should be stale
+    stale_titles = [it['title'] for it in result]
+    assert 'Set up webhook integration' in stale_titles
+    assert 'Notion integration research' in stale_titles
+    # Recent item should NOT be stale
+    assert 'Review pricing page' not in stale_titles
+
+
+def test_add_item(tasks_file):
+    result = add_item(tasks_file, 'New backlog task', dept='Sales', priority='low')
+    assert '✅' in result
+    assert '4/25' in result
+
+    content = tasks_file.read_text()
+    assert '**New backlog task**' in content
+    assert '#Sales' in content
+    assert f'created::{date.today().isoformat()}' in content
+
+
+def test_add_item_respects_cap(tasks_file):
+    os.environ['PARKING_LOT_CAP'] = '3'
+    try:
+        result = add_item(tasks_file, 'Should fail')
+        assert '❌' in result
+        assert 'full' in result.lower()
+    finally:
+        del os.environ['PARKING_LOT_CAP']
+
+
+def test_promote_item(tasks_file):
+    result = promote_item(tasks_file, 1)
+    assert '✅' in result
+    assert 'Set up webhook integration' in result
+
+    content = tasks_file.read_text()
+    # Should be removed from parking lot
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    items = _parse_items(lines, start, end)
+    titles = [it['title'] for it in items]
+    assert 'Set up webhook integration' not in titles
+
+    # Should appear in objectives section (before parking lot)
+    pl_start = content.index('## 🅿️ Parking Lot')
+    assert '**Set up webhook integration**' in content[:pl_start]
+    # created:: field should be stripped
+    obj_section = content[:pl_start]
+    assert 'created::' not in obj_section or 'Set up webhook' not in obj_section.split('created::')[0]
+
+
+def test_drop_item(tasks_file, tmp_path):
+    archive_dir = tmp_path / 'Done Archive'
+    result = drop_item(tasks_file, 2, archive_dir=archive_dir)
+    assert '✅' in result
+    assert 'Review pricing page' in result
+
+    # Removed from parking lot
+    content = tasks_file.read_text()
+    assert 'Review pricing page' not in content
+
+    # Archived
+    archives = list(archive_dir.iterdir())
+    assert len(archives) == 1
+    arc_content = archives[0].read_text()
+    assert 'Review pricing page' in arc_content
+    assert '(dropped)' in arc_content
+    assert '## Marketing' in arc_content
+
+
+def test_drop_nonexistent_item(tasks_file):
+    result = drop_item(tasks_file, 99)
+    assert '❌' in result
+
+
+def test_promote_nonexistent_item(tasks_file):
+    result = promote_item(tasks_file, 99)
+    assert '❌' in result
+
+
+def test_no_parking_lot_section(tmp_path):
+    f = tmp_path / 'tasks.md'
+    f.write_text('# Tasks\n\n- [ ] **Task 1**\n')
+    assert 'No Parking Lot' in list_items(f)
+    assert '❌' in add_item(f, 'test')


### PR DESCRIPTION
## Summary
Add `parking-lot` subcommand with full CRUD operations for the 🅿️ Parking Lot section.

### Operations
- `tasks.py parking-lot list` — items with stale status + count
- `tasks.py parking-lot add "title" --dept Dev --priority low` — respects hard cap (25)
- `tasks.py parking-lot stale` — stale items as JSON (>30 days)
- `tasks.py parking-lot promote <id>` — move to objectives section
- `tasks.py parking-lot drop <id>` — remove + archive as dropped

### Implementation
- New module: `scripts/parking_lot.py` (~300 lines)
- CLI wiring in `scripts/tasks.py` (single dispatch function)
- Atomic writes via tempfile+rename
- Configurable: `PARKING_LOT_CAP` (default 25), `PARKING_LOT_STALE_DAYS` (default 30)

### Tests
12 new tests in `tests/test_parking_lot.py`:
- Section bounds detection, item parsing, stale detection
- List/stale output format, add with cap enforcement
- Promote (moves to objectives, strips created:: field)
- Drop (removes + archives by department)
- Error cases (nonexistent items, missing section)

**26/26 tests pass** (14 existing + 12 new).

Closes #72
Part of epic #69