### PR TITLE
fix: address 5 codex review findings from Layer 2

### DIFF
--- a/scripts/delegation.py
+++ b/scripts/delegation.py
@@ -296,6 +296,20 @@ def extend_item(path: Path, item_id: int, new_followup: str) -> dict:
     return target
 
 
+def get_active_item(path: Path, item_id: int) -> dict:
+    """Return an active delegated item without modifying the file."""
+    content = path.read_text()
+    lines = content.split('\n')
+
+    active_start, active_end = _find_section(lines, 'Active')
+    items = _parse_section_items(lines, active_start, active_end) if active_start >= 0 else []
+    target = next((it for it in items if it['id'] == item_id), None)
+    if not target:
+        raise ValueError(f"Item #{item_id} not found in Active section.")
+
+    return dict(target)
+
+
 def take_back_item(path: Path, item_id: int) -> dict:
     """Remove a delegated item and return it for re-insertion into tasks file."""
     content = path.read_text()

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -463,8 +463,8 @@ def cmd_delegated(args):
             sys.exit(1)
     elif sub == 'take-back':
         try:
-            item = delegation.take_back_item(path, args.id)
-            # Re-insert into work tasks
+            item = delegation.get_active_item(path, args.id)
+            # Re-insert into work tasks first; only delete delegated entry after write succeeds.
             tasks_file, _ = get_tasks_file(personal=False)
             content = tasks_file.read_text()
             dept_tag = f" #{item.get('department')}" if item.get('department') else ''
@@ -480,6 +480,7 @@ def cmd_delegated(args):
                     insert_at = i + 1
             lines.insert(insert_at, task_line)
             tasks_file.write_text('\n'.join(lines))
+            delegation.take_back_item(path, args.id)
             print(f"✅ Took back: {item['title']} (added to {tasks_file.name})")
         except ValueError as e:
             print(f"❌ {e}")
@@ -603,4 +604,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Tests for archive operations."""
 
+from datetime import date
 from pathlib import Path
 import pytest
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from archive import archive_week, get_archive_dir
+import archive
+from archive import archive_week, get_archive_dir, consolidate_month, archive_stats
 
 
 def test_archive_week_no_completed(tmp_path):
@@ -35,3 +37,54 @@ def test_get_archive_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("TASK_TRACKER_ARCHIVE_DIR", str(custom_dir))
     archive_dir = get_archive_dir(tasks_file)
     assert archive_dir == custom_dir
+
+
+def test_consolidate_month_includes_previous_iso_year_week(tmp_path):
+    archive_dir = tmp_path / "Done Archive"
+    archive_dir.mkdir()
+    (archive_dir / "2020-W53.md").write_text("""# Done Archive — Week of Dec 28, 2020 (W53)
+
+## Dev
+- [x] Cross-year item ✅ 2021-01-02
+""")
+    (archive_dir / "2021-W01.md").write_text("""# Done Archive — Week of Jan 04, 2021 (W01)
+
+## Dev
+- [x] January item ✅ 2021-01-06
+""")
+
+    result = consolidate_month(archive_dir, "2021-01")
+    assert "error" not in result
+    weekly_names = {f.name for f in result["weekly_files"]}
+    assert "2020-W53.md" in weekly_names
+    assert "2021-W01.md" in weekly_names
+
+    monthly_content = result["monthly_file"].read_text()
+    assert "Cross-year item" in monthly_content
+    assert "January item" in monthly_content
+
+
+def test_archive_stats_ignores_monthly_consolidation_files(tmp_path, monkeypatch):
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 2, 15)
+
+    monkeypatch.setattr(archive, "date", FakeDate)
+
+    archive_dir = tmp_path / "Done Archive"
+    archive_dir.mkdir()
+    (archive_dir / "2026-W07.md").write_text("""# Done Archive — Week of Feb 09, 2026 (W07)
+
+## Dev
+- [x] Weekly item ✅ 2026-02-10
+""")
+    (archive_dir / "2026-02-monthly.md").write_text("""# Done Archive — February 2026
+
+## Dev
+- [x] Weekly item ✅ 2026-02-10
+""")
+
+    stats = archive_stats(archive_dir, "month")
+    assert stats["total"] == 1
+    assert stats["by_department"] == {"Dev": 1}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,46 @@
+"""Tests for tasks CLI command handlers."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
+
+import tasks
+
+
+def test_cmd_delegated_take_back_write_failure_keeps_delegated_item(tmp_path, monkeypatch):
+    delegation_file = tmp_path / 'Delegated.md'
+    delegation_file.write_text("""# Delegated Tasks
+
+## Active
+- [ ] **Check merch delivery** → Alex [delegated::2026-02-10] [followup::2026-02-17] #Ops
+
+## Awaiting Follow-up
+
+## Completed
+""")
+    tasks_file = tmp_path / 'Work Tasks.md'
+    tasks_file.write_text("""# Weekly Objectives
+
+## Objectives
+""")
+
+    monkeypatch.setenv('TASK_TRACKER_DELEGATION_FILE', str(delegation_file))
+    monkeypatch.setattr(tasks, 'get_tasks_file', lambda personal=False: (tasks_file, 'markdown'))
+
+    original_write_text = Path.write_text
+
+    def fail_task_file_write(path_obj, content, *args, **kwargs):
+        if path_obj == tasks_file:
+            raise OSError('simulated write failure')
+        return original_write_text(path_obj, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'write_text', fail_task_file_write)
+
+    with pytest.raises(OSError, match='simulated write failure'):
+        tasks.cmd_delegated(SimpleNamespace(del_command='take-back', id=1))
+
+    assert 'Check merch delivery' in delegation_file.read_text()


### PR DESCRIPTION
## Summary

Fixes all 5 bugs found in the Codex gpt-5.3-codex review of the combined Layer 2 diff (1386 lines).

## Fixes

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | **P1** | `take-back` deletes from delegation before writing to tasks file — data loss if write fails | New `get_active_item()` reads without modifying; tasks file written first, then `take_back_item()` called |
| 2 | **P2** | `drop_item`/`promote_item` only remove checkbox line, orphaning indented child lines | New `_item_block_end()` helper; both functions now handle full item blocks |
| 3 | **P2** | `drop_item` archive filename uses `today.year` — wrong at ISO year boundaries (Jan 1 = W53 of prior year) | Uses `isocalendar()` to get `iso_year` |
| 4 | **P2** | `consolidate_month` only globs current year — misses cross-year ISO weeks (2025-W53 for Jan 2026) | Also globs `(year-1)-W*.md`; checks all 7 days of week against target month |
| 5 | **P2** | `archive_stats` globs `*.md` — double-counts when both weekly + monthly files exist | Restricted glob to `YYYY-W[0-9][0-9].md` (weekly files only) |

## Tests

38 → 44 tests (+6 new regression tests):
- `test_cmd_delegated_take_back_write_failure_keeps_delegated_item` — simulates OSError on tasks file write
- `test_drop_item_removes_child_lines` — verifies indented notes removed with parent
- `test_promote_item_moves_child_lines_with_parent` — verifies notes move to objectives section
- `test_drop_item_uses_iso_year_for_archive_filename` — monkeypatches date to Jan 1 (ISO W53)
- `test_consolidate_month_includes_previous_iso_year_week` — 2020-W53 included in 2021-01
- `test_archive_stats_ignores_monthly_consolidation_files` — weekly + monthly = count 1 not 2

## Files Changed

- `scripts/tasks.py` — reordered take-back operations
- `scripts/delegation.py` — added `get_active_item()`
- `scripts/parking_lot.py` — `_item_block_end()`, child line handling, ISO year fix
- `scripts/archive.py` — cross-year glob, weekly-only stats glob
- `tests/test_tasks.py` — new file
- `tests/test_archive.py` — 2 new tests
- `tests/test_parking_lot.py` — 3 new tests

Tool: Codex CLI (gpt-5.3-codex) in tmux, Bug 5 glob fix applied during session.