### PR TITLE
feat: objective-level completion tracking (#71)

### DIFF
--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+from types import SimpleNamespace
+import json
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import tasks
+from utils import parse_tasks, summarize_objective_progress
+from test_objective_parser import OBJECTIVES_CONTENT
+
+
+def test_cmd_objectives_text_output(monkeypatch, capsys):
+    tasks_data = parse_tasks(OBJECTIVES_CONTENT)
+    monkeypatch.setattr(
+        tasks,
+        "load_tasks",
+        lambda personal=False: (OBJECTIVES_CONTENT, tasks_data),
+    )
+
+    tasks.cmd_objectives(SimpleNamespace(personal=False, json=False, at_risk=False))
+
+    out = capsys.readouterr().out
+    assert "Launch job posting" in out
+    assert "66.7%" in out
+    assert "#HR" in out
+    assert "#high" in out
+    assert "✅ Draft job description" in out
+    assert "⬜ Post on LinkedIn" in out
+
+
+def test_cmd_objectives_json_output(monkeypatch, capsys):
+    tasks_data = parse_tasks(OBJECTIVES_CONTENT)
+    monkeypatch.setattr(
+        tasks,
+        "load_tasks",
+        lambda personal=False: (OBJECTIVES_CONTENT, tasks_data),
+    )
+
+    tasks.cmd_objectives(SimpleNamespace(personal=False, json=True, at_risk=False))
+
+    output = json.loads(capsys.readouterr().out)
+    assert isinstance(output, list)
+    assert len(output) == 2
+
+    launch = next(item for item in output if item["title"] == "Launch job posting")
+    assert launch["department"] == "HR"
+    assert launch["priority"] == "high"
+    assert launch["total_tasks"] == 3
+    assert launch["completed_tasks"] == 2
+    assert launch["completion_pct"] == pytest.approx(66.7)
+    assert launch["tasks"][0] == {"title": "Draft job description", "done": True}
+
+    deal = next(item for item in output if item["title"] == "Close Fizzi deal")
+    assert deal["total_tasks"] == 2
+    assert deal["completed_tasks"] == 0
+    assert deal["completion_pct"] == pytest.approx(0.0)
+
+
+def test_cmd_objectives_at_risk_filter(monkeypatch, capsys):
+    tasks_data = parse_tasks(OBJECTIVES_CONTENT)
+    monkeypatch.setattr(
+        tasks,
+        "load_tasks",
+        lambda personal=False: (OBJECTIVES_CONTENT, tasks_data),
+    )
+
+    tasks.cmd_objectives(SimpleNamespace(personal=False, json=False, at_risk=True))
+
+    out = capsys.readouterr().out
+    assert "Close Fizzi deal" in out
+    assert "Launch job posting" not in out
+
+
+def test_cmd_objectives_graceful_skip_legacy(monkeypatch, capsys):
+    legacy_content = """## 🔴 Q1: Urgent & Important
+- [ ] **Ship release**
+"""
+    tasks_data = parse_tasks(legacy_content, format="obsidian")
+    monkeypatch.setattr(
+        tasks,
+        "load_tasks",
+        lambda personal=False: (legacy_content, tasks_data),
+    )
+
+    tasks.cmd_objectives(SimpleNamespace(personal=False, json=False, at_risk=False))
+
+    out = capsys.readouterr().out
+    assert "Objective tracking is only available for Objectives format files." in out
+
+
+def test_objective_progress_summary():
+    tasks_data = parse_tasks(OBJECTIVES_CONTENT)
+    summary = summarize_objective_progress(tasks_data)
+
+    assert summary["total_objectives"] == 2
+    assert summary["on_track_objectives"] == 1
+    at_risk_titles = [item["title"] for item in summary["at_risk_objectives"]]
+    assert at_risk_titles == ["Close Fizzi deal"]


### PR DESCRIPTION
## Summary

Implements issue #71 — the final issue in epic #69. Adds objective-level completion tracking with CLI command, JSON output, and standup integration.

Closes #71
Closes #69

## Changes

### New Command: `tasks.py objectives`
```
$ tasks.py objectives
🎯 Launch job posting — 67% (2/3) #HR #high
  ✅ Draft job description
  ✅ Research platforms
  ⬜ Post on LinkedIn

🎯 Close Fizzi deal — 0% (0/2) #Sales #urgent
  ⬜ Call re: pricing
  ⬜ Send follow-up proposal
```

**Flags:**
- `--json` — Machine-readable output (list of objective dicts with completion_pct, tasks, etc.)
- `--at-risk` — Only show objectives with 0% completion
- Graceful skip for old Q1-Q4 format files

### New Helpers (utils.py)
- `get_objective_progress(tasks_data)` — Groups tasks by parent_objective, computes per-objective completion %
- `summarize_objective_progress(tasks_data)` — Returns total/on_track/at_risk counts

### Standup Integration (standup.py)
Both split-message and single-message standup formats now include:
```
🎯 Objective Progress:
  • On track: 1/2
  • At risk (0%):
    • Close Fizzi deal
```

## Files Changed
- `scripts/utils.py` — +79 lines (get_objective_progress, summarize_objective_progress)
- `scripts/tasks.py` — +56 lines (cmd_objectives, objectives subcommand, _format_completion_pct)
- `scripts/standup.py` — +38 lines (objective progress in both output paths)
- `tests/test_objectives.py` — +101 lines (5 new tests)

## Tests
44 → 49 passing (+5 new):
- `test_cmd_objectives_text_output` — verifies formatted output with completion %
- `test_cmd_objectives_json_output` — verifies JSON structure, values, and pytest.approx for 66.7%
- `test_cmd_objectives_at_risk_filter` — 0% objectives only
- `test_cmd_objectives_graceful_skip_legacy` — old format gets skip message
- `test_objective_progress_summary` — helper returns correct counts

## Tool
Codex CLI (gpt-5.3-codex) in tmux, 540s timeout