### PR TITLE
docs: skillcraft compliance pass for task-tracker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,232 +2,55 @@
 
 Personal task management with daily standups and weekly reviews.
 
-## Features
+## Documentation Map
 
-- 📋 **Task Management:** Create, list, complete, and archive tasks
-- 📊 **Daily Standup:** See today's priorities, blockers, and recent completions
-- 📅 **Weekly Review:** Summarize progress and plan the week ahead
-- 🏷️ **Priority Levels:** High (🔴), Medium (🟡), Low/Delegated (🟢)
-- ⏰ **Due Dates:** Track deadlines and filter by due date
-- 🚧 **Blockers:** Identify tasks blocking team members
-- 📱 **Telegram Integration:** Slash commands for quick access
-- 🤖 **Automated Briefings:** Optional cron jobs for daily/weekly summaries
+- **`SKILL.md`**: lean runtime entrypoint (when to use, quick start, core commands)
+- **`references/setup-and-config.md`**: environment variables, defaults, troubleshooting
+- **`references/commands.md`**: full command catalog
+- **`references/obsidian-and-dataview.md`**: Obsidian patterns and Dataview snippets
+- **`references/eod-sync.md`**: EOD sync and weekly embed refresh
+- **`references/migration.md`**: migration + legacy compatibility notes
+- **`references/task-format.md`**: legacy task format specification
+- **`TELEGRAM.md`**: optional Telegram slash command setup
 
 ## Quick Start
 
 ```bash
-# Daily standup
-python3 ~/clawd/skills/task-tracker/scripts/standup.py
+git clone https://github.com/kesslerio/task-tracker-openclaw-skill.git <workspace>/<skill>
+cd <workspace>/<skill>
 
-# List all tasks
-python3 ~/clawd/skills/task-tracker/scripts/tasks.py list
+# Required for work workflows
+export TASK_TRACKER_WORK_FILE="$HOME/path/to/Work Tasks.md"
 
-# Add a task
-python3 ~/clawd/skills/task-tracker/scripts/tasks.py add "Task description" --priority high --due 2026-01-25
+# Required only for --personal commands
+export TASK_TRACKER_PERSONAL_FILE="$HOME/path/to/Personal Tasks.md"
 
-# Mark task done (fuzzy match)
-python3 ~/clawd/skills/task-tracker/scripts/tasks.py done "task keyword"
-
-# Weekly review
-python3 ~/clawd/skills/task-tracker/scripts/weekly_review.py
-```
-
-## Installation
-
-1. Clone to your OpenClaw skills directory:
-   ```bash
-   git clone https://github.com/kesslerio/task-tracker-openclaw-skill.git \
-       ~/clawd/skills/task-tracker
-   ```
-
-2. Create tasks file from template:
-   ```bash
-   cp ~/clawd/skills/task-tracker/assets/templates/TASKS.md \
-       ~/clawd/memory/work/TASKS.md
-   ```
-
-3. (Optional) Set up Telegram slash commands - see [TELEGRAM.md](TELEGRAM.md)
-
-## Task File Format
-
-Tasks are stored in `~/clawd/memory/work/TASKS.md` using this format:
-
-```markdown
-## 🔴 High Priority (This Week)
-
-- [ ] **Task title** — Brief description
-  - Owner: sarah
-  - Due: 2026-01-29
-  - Status: Todo
-  - Blocks: teammate (reason)
-```
-
-### Priority Levels
-- **🔴 High:** Blocking others, critical deadline, revenue impact
-- **🟡 Medium:** Important but not urgent
-- **🟢 Low/Delegated:** Monitoring, no deadline pressure
-
-### Statuses
-- `Todo` → `In Progress` → `Done`
-- `Blocked` (waiting on external)
-- `Waiting` (delegated, monitoring)
-
-## Commands
-
-### Daily Standup
-```bash
+python3 scripts/tasks.py list
 python3 scripts/standup.py
-python3 scripts/standup.py --compact-json   # DONEs/Calendar DOs/DOs API shape
-```
-
-### State transitions
-```bash
-python3 scripts/tasks.py state pause "task title" --until 2026-03-01
-python3 scripts/tasks.py state delegate "task title" --to Alex --followup 2026-03-01
-python3 scripts/tasks.py state backlog "task title"
-python3 scripts/tasks.py state drop "task title"
-python3 scripts/tasks.py promote-from-backlog --cap 3
-python3 scripts/tasks.py review-backlog --stale-days 45 --json
-```
-
-Output:
-- 🎯 #1 Priority
-- ⏰ Due today
-- 🔴 High priority tasks
-- ✅ Recently completed
-
-### Weekly Review
-```bash
 python3 scripts/weekly_review.py
 ```
 
-Output:
-- Last week's completions
-- Tasks pushed to this week
-- This week's priorities
-- Automatically archives done tasks
+## What this skill provides
 
-### Task Operations
+- Task list/add/done workflows for work and personal boards
+- Daily standup summaries (`standup.py`, `personal_standup.py`)
+- Weekly review + archive workflows (`weekly_review.py`, `archive.py`)
+- State transitions and backlog hygiene (`tasks.py state ...`)
+- Action extraction from notes (`extract_tasks.py`)
+- End-of-day sync into weekly TODOs (`eod_sync.py`)
+- Weekly transclusion refresh for Obsidian (`update_weekly_embeds.py`)
 
-**List tasks:**
-```bash
-python3 scripts/tasks.py list                          # All tasks
-python3 scripts/tasks.py list --priority high          # High priority only
-python3 scripts/tasks.py list --status done            # Completed tasks
-python3 scripts/tasks.py list --due today              # Due today
-python3 scripts/tasks.py list --due this-week          # Due this week
-python3 scripts/tasks.py list --owner your-name           # My tasks
-python3 scripts/tasks.py list --completed-since 24h    # Done last 24h
-python3 scripts/tasks.py list --completed-since 7d     # Done last week
-```
+## Compatibility
 
-**Add task:**
-```bash
-python3 scripts/tasks.py add "Task description" \
-  --priority high \
-  --due 2026-01-29 \
-  --owner your-name \
-  --blocks "teammate"
-```
+This repository keeps existing scripts and command behavior intact. The recent docs refactor reorganizes guidance into `references/` and keeps legacy migration notes available.
 
-**Complete task:**
-```bash
-python3 scripts/tasks.py done "task keyword"
-```
-
-Uses fuzzy matching - just type a few words from the task title.
-
-**Show blockers:**
-```bash
-python3 scripts/tasks.py blockers                # All blockers
-python3 scripts/tasks.py blockers --person lilla # Blocking specific person
-```
-
-**Archive completed tasks:**
-```bash
-python3 scripts/tasks.py archive
-```
-
-Aggregates completions from daily notes into quarterly `ARCHIVE-YYYY-QN.md`.
-
-## Telegram Slash Commands
-
-Optional integration for Telegram users. See [TELEGRAM.md](TELEGRAM.md) for setup.
-
-**Commands:**
-- `/daily` - Daily standup
-- `/weekly` - Weekly priorities
-- `/done24h` - Completed last 24 hours
-- `/done7d` - Completed last 7 days
-
-## Cron Jobs (Optional)
-
-Set up automated standups and reviews:
+## Development
 
 ```bash
-# Daily standup (8:30 AM PT, weekdays)
-openclaw cron add \
-  --name "Daily Standup" \
-  --schedule "30 8 * * 1-5" \
-  --timezone "America/Los_Angeles" \
-  --command "python3 ~/clawd/skills/task-tracker/scripts/standup.py"
-
-# Weekly review (9:00 AM PT, Mondays)
-openclaw cron add \
-  --name "Weekly Review" \
-  --schedule "0 9 * * 1" \
-  --timezone "America/Los_Angeles" \
-  --command "python3 ~/clawd/skills/task-tracker/scripts/weekly_review.py"
+# run tests
+pytest -q
 ```
-
-## Workflow
-
-1. **Morning:** Daily standup surfaces #1 priority
-2. **Throughout day:** Update status as work progresses
-3. **After meetings:** Extract tasks with `extract_tasks.py`
-4. **End of week:** Weekly review archives done, plans next week
-
-## Files
-
-```
-task-tracker/
-├── README.md              # This file
-├── SKILL.md               # OpenClaw skill documentation
-├── TELEGRAM.md            # Telegram integration guide
-├── scripts/
-│   ├── tasks.py           # Task CRUD operations
-│   ├── standup.py         # Daily standup generator
-│   ├── weekly_review.py   # Weekly review + archiving
-│   ├── extract_tasks.py   # Extract tasks from notes
-│   ├── telegram-commands.sh # Telegram slash command wrapper
-│   └── init.py            # Initialize tasks file
-├── assets/
-│   └── templates/
-│       └── TASKS.md       # Task file template
-└── references/
-    └── task-format.md     # Task format specification
-```
-
-## Integration with OpenClaw
-
-The agent automatically:
-- Recognizes task-related questions ("What's my #1 priority?")
-- Runs standup when asked ("daily standup")
-- Updates tasks when you say "mark X done"
-- Filters tasks by criteria ("show high priority tasks due this week")
-
-## Dependencies
-
-- Python 3.10+
-- OpenClaw (for cron/messaging integration)
 
 ## License
 
-Apache 2.0 - See [LICENSE](LICENSE) file for details.
-
-## Related Skills
-
-- **[finance-news](https://github.com/kesslerio/finance-news-openclaw-skill):** AI-powered market briefings with multi-source aggregation (WSJ, Barron's, CNBC), portfolio tracking, and automated WhatsApp delivery in German/English
-- **[oura-analytics](https://github.com/kesslerio/openclaw-oura-skill):** Sleep and health tracking
-- **[session-logs](https://github.com/kesslerio/openclaw-session-logs-skill):** Search conversation history
-- **[task-tracker](https://github.com/kesslerio/task-tracker-openclaw-skill):** This skill
+Apache 2.0 - See [LICENSE](LICENSE).

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,531 +5,145 @@ homepage: https://github.com/kesslerio/task-tracker-openclaw-skill
 metadata: {"openclaw":{"emoji":"📋","requires":{"env":["TASK_TRACKER_WORK_FILE","TASK_TRACKER_PERSONAL_FILE"]},"install":[{"id":"verify-paths","kind":"check","label":"Verify task file paths are configured"}]}}
 ---
 
-<div align="center">
-
-![Task Tracker](https://img.shields.io/badge/Task_Tracker-OpenClaw_skill-blue?style=for-the-badge&logo=checklist)
-![Python](https://img.shields.io/badge/Python-3.10+-yellow?style=flat-square&logo=python)
-![Status](https://img.shields.io/badge/Status-Production-green?style=flat-square)
-![Issues](https://img.shields.io/badge/Issues-0-black?style=flat-square)
-![Last Updated](https://img.shields.io/badge/Last_Updated-Jan_2026-orange?style=flat-square)
-
-**Personal task management with daily standups and weekly reviews**
-
-[Homepage](https://github.com/kesslerio/task-tracker-openclaw-skill) • [Trigger Patterns](#what-this-skill-does) • [Commands](#commands-reference)
-
-</div>
-
----
-
 # Task Tracker
 
-A personal task management skill for daily standups and weekly reviews. Tracks work and personal tasks from your Obsidian vault (or standalone markdown files), surfaces priorities, and manages blockers.
+Personal task management for work + personal workflows, with daily standups and weekly reviews.
 
----
+## When to Use
 
-## What This Skill Does
+Use this skill when the user asks to:
 
-1. **Lists tasks** - Shows what's on your plate, filtered by priority, status, or deadline
-2. **Daily standup** - Shows today's #1 priority, blockers, and what was completed (Work & Personal)
-3. **Weekly review** - Summarizes last week, archives done items, plans this week
-4. **Add tasks** - Create new tasks with priority and due date
-5. **Complete tasks** - Mark tasks as done (logged to daily notes, removed from board)
-6. **Extract from notes** - Pull action items from meeting notes
-7. **Dual support** - Separate Work and Personal task workflows
-
----
-
-## Configuration
-
-Configure paths via environment variables in your shell profile or `.openclaw/.env`:
-
-```bash
-# Recommended: Override the default work task file path
-export TASK_TRACKER_WORK_FILE="$HOME/Obsidian/03-Areas/Work/Work Tasks.md"
-
-# Optional: Personal task file (required only for --personal commands)
-export TASK_TRACKER_PERSONAL_FILE="$HOME/Obsidian/03-Areas/Personal/Personal Tasks.md"
-
-# Optional: Custom archive location
-export TASK_TRACKER_ARCHIVE_DIR="$HOME/clawd/memory/work"
-
-# Optional: Legacy fallback (if Obsidian files don't exist)
-export TASK_TRACKER_LEGACY_FILE="$HOME/clawd/memory/work/TASKS.md"
-
-# Optional: Daily notes directory for completion logging (YYYY-MM-DD.md files)
-export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/Obsidian/01-TODOs/Daily"
-
-# Required for EOD sync: path to Weekly TODOs file
-export TASK_TRACKER_WEEKLY_TODOS="$HOME/Obsidian/01-TODOs/Weekly TODOs.md"
-```
-
-**Default paths (used when env vars are not set):**
-- Work: `~/Obsidian/03-Areas/Work/Work Tasks.md`
-- Personal: `~/Obsidian/03-Areas/Personal/Personal Tasks.md`
-- Legacy: `~/clawd/memory/work/TASKS.md`
-
-Setting `TASK_TRACKER_WORK_FILE` explicitly is recommended — the defaults assume an Obsidian vault layout.
-
----
-
-## Obsidian Setup
-
-This skill reads tasks directly from markdown files. Works best with Obsidian but any markdown editor works.
-
-### Required Obsidian Plugins
-
-| Plugin | Purpose | Required? |
-|--------|---------|-----------|
-| **Dataview** | TASK queries in daily notes | ✅ Yes |
-| **Templater** | Auto-populate daily note templates | Optional |
-| **Periodic Notes** | Daily/weekly note templates | Optional |
-| **[Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)** | Advanced task management | Optional (recommended) |
-
-> **Note:** The Tasks plugin provides a richer task format with `📅` due dates, `🔺` priorities, and `✅` completion dates. This skill supports both the emoji format (below) and the Tasks plugin format.
-
-### Task Format
-
-This skill supports **two task formats**:
-
-#### 1. Tasks Plugin Format (Recommended)
-
-If you use the [Obsidian Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) plugin:
-
-```markdown
-- [ ] **Task name** 📅 2026-01-22 🔺 #tag
-- [x] Completed task ✅ 2026-01-20 🔼
-```
-
-**Features:**
-- `📅 YYYY-MM-DD` — Due date
-- `🔺` — Urgent (maps to Q1)
-- `⏫` — High priority (maps to Q1)
-- `🔼` — Medium priority (maps to Q2)
-- `🔽`/`⏬` — Low priority (maps to backlog)
-- `✅ YYYY-MM-DD` — Completion timestamp
-- `#tag` — Department/category tags
-
-**Sub-sections as departments:**
-```markdown
-### 👥 Hiring #hiring
-- [ ] Post to Indeed 📅 2026-02-17 🔺
-```
-
-#### 2. Emoji Date Format (Legacy/Dataview)
-
-Tasks use the **emoji date format** for Dataview compatibility:
-
-```markdown
-- [ ] **Task name** 🗓️2026-01-22 area:: Sales
-  - Additional notes here
-```
-
-**Inline Fields (Legacy format):**
-
-| Field | Purpose | Example |
-|-------|---------|---------|
-| `🗓️YYYY-MM-DD` | Due date | `🗓️2026-01-22` |
-| `area::` | Category/area | `area:: Sales` |
-| `goal::` | Weekly goal link | `goal:: [[2026-W04]]` |
-| `owner::` | Task owner | `owner:: Sarah` |
-
-### File Structure (Eisenhower Matrix)
-
-```markdown
-# Work Tasks
-
-## 🔴 Q1: Do Now (Urgent & Important)
-
-> Max 5 tasks. If overloaded, triage to Q2 or delegate.
-
-- [ ] **Critical task** 🗓️2026-01-22 area:: Operations
-
-## 🟡 Q2: Schedule (Important, Not Urgent)
-
-> Deep work, strategic tasks. Schedule on calendar.
-
-- [ ] **Strategic task** 🗓️2026-01-26 area:: Planning
-
-## 🟠 Q3: Waiting (Blocked on External)
-
-> Tasks waiting on others or external factors.
-
-- [ ] **Blocked task** owner:: Sarah
-
-## 👥 Team Tasks (Monitor/Check-in)
-
-> Delegated tasks you're monitoring.
-
-- [ ] **Team member's task** owner:: Alex
-
-## ⚪ Q4: Backlog (Someday/Maybe)
-
-> Low priority, not scheduled.
-
-- [ ] **Future idea**
-```
-
-### Personal Tasks Structure
-
-```markdown
-# Personal Tasks
-
-## 🔴 Must Do Today
-- [ ] **Urgent personal task** 🗓️2026-01-22
-
-## 🟡 Should Do This Week
-- [ ] **Important task** 🗓️2026-01-26
-
-## 🟠 Waiting On
-- [ ] **Waiting for response**
-
-## ⚪ Backlog
-- [ ] **Someday task**
-```
-
----
+- Run a daily or personal standup
+- Run a weekly review
+- Add, list, update, or complete tasks
+- Check blockers or due dates
+- Extract actions from meeting notes
+- Sync completed daily items to weekly todos
 
 ## Quick Start
 
-### List Work Tasks
+Prefer environment-based configuration first, then run scripts from `<workspace>/<skill>`.
+
+### 1) Configure paths (env-first)
+
 ```bash
+# Required for work task workflows
+export TASK_TRACKER_WORK_FILE="$HOME/path/to/Work Tasks.md"
+
+# Required only for --personal commands
+export TASK_TRACKER_PERSONAL_FILE="$HOME/path/to/Personal Tasks.md"
+
+# Optional
+export TASK_TRACKER_ARCHIVE_DIR="$HOME/path/to/archive"
+export TASK_TRACKER_LEGACY_FILE="$HOME/path/to/TASKS.md"
+export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/path/to/Daily"
+export TASK_TRACKER_WEEKLY_TODOS="$HOME/path/to/Weekly TODOs.md"
+```
+
+Defaults exist, but explicit env vars are recommended for portability.
+
+### 2) Run from the skill directory
+
+```bash
+cd <workspace>/<skill>
+# Example: cd ~/projects/skills/shared/task-tracker
+```
+
+### 3) Core commands
+
+```bash
+# Work
 python3 scripts/tasks.py list
-
-# Due today
-python3 scripts/tasks.py list --due today
-
-# By priority
-python3 scripts/tasks.py list --priority high
-```
-
-### List Personal Tasks
-```bash
-python3 scripts/tasks.py --personal list
-
-# Due today
-python3 scripts/tasks.py --personal list --due today
-```
-
-### Daily Standup
-```bash
-# Work standup
 python3 scripts/standup.py
+python3 scripts/weekly_review.py
 
-# Personal standup
+# Personal
+python3 scripts/tasks.py --personal list
 python3 scripts/personal_standup.py
 ```
 
-### Weekly Review
+## Core Commands
+
+### Task listing and filtering
+
 ```bash
+python3 scripts/tasks.py list
+python3 scripts/tasks.py list --priority high
+python3 scripts/tasks.py list --due today
+python3 scripts/tasks.py list --due this-week
+python3 scripts/tasks.py blockers
+```
+
+### Add and complete tasks
+
+```bash
+python3 scripts/tasks.py add "Draft proposal" --priority high --due 2026-01-23
+python3 scripts/tasks.py --personal add "Call mom" --priority high --due 2026-01-22
+python3 scripts/tasks.py done "proposal"
+python3 scripts/tasks.py --personal done "call mom"
+```
+
+### State transitions and backlog ops
+
+```bash
+python3 scripts/tasks.py state pause "task title" --until 2026-03-01
+python3 scripts/tasks.py state delegate "task title" --to Alex --followup 2026-03-01
+python3 scripts/tasks.py state backlog "task title"
+python3 scripts/tasks.py state drop "task title"
+python3 scripts/tasks.py promote-from-backlog --cap 3
+python3 scripts/tasks.py review-backlog --stale-days 45 --json
+```
+
+### Standup and review
+
+```bash
+python3 scripts/standup.py
+python3 scripts/standup.py --compact-json
+python3 scripts/personal_standup.py
 python3 scripts/weekly_review.py
 ```
 
----
-
-## Agent Integration
-
-Use explicit paths with a `{baseDir}` variable when invoking scripts from agents.
-
-Example:
-```bash
-python3 {baseDir}/scripts/standup.py
-```
-
-Available direct script commands:
-```bash
-python3 {baseDir}/scripts/standup.py
-python3 {baseDir}/scripts/personal_standup.py
-python3 {baseDir}/scripts/weekly_review.py
-python3 {baseDir}/scripts/tasks.py list
-python3 {baseDir}/scripts/tasks.py --personal list
-python3 {baseDir}/scripts/tasks.py add "Task title" --priority high --due 2026-01-23
-python3 {baseDir}/scripts/tasks.py done "task query"
-python3 {baseDir}/scripts/tasks.py blockers
-python3 {baseDir}/scripts/extract_tasks.py --from-text "Meeting notes"
-```
-
-Available heartbeat wrapper commands:
-```bash
-bash {baseDir}/scripts/task-shortcuts.sh daily
-bash {baseDir}/scripts/task-shortcuts.sh weekly
-bash {baseDir}/scripts/task-shortcuts.sh done24h
-bash {baseDir}/scripts/task-shortcuts.sh done7d
-```
-
----
-
-## Commands Reference
-
-### List Tasks
-```bash
-# All tasks
-tasks.py list
-tasks.py --personal list
-
-# Only high priority
-tasks.py list --priority high
-tasks.py --personal list --priority high
-
-# Due today or this week
-tasks.py list --due today
-tasks.py list --due this-week
-
-# Only blocked
-tasks.py blockers
-```
-
-### Add Task
-```bash
-# Work task
-tasks.py add "Draft project proposal" --priority high --due 2026-01-23
-
-# Personal task
-tasks.py --personal add "Call mom" --priority high --due 2026-01-22
-
-# With area
-tasks.py add "Review budget" --priority medium --due 2026-01-25 --area Finance
-```
-
-### Complete Task
-```bash
-tasks.py done "proposal"  # Fuzzy match - finds "Draft project proposal"
-tasks.py --personal done "call mom"
-```
-
-### Show Blockers
-```bash
-tasks.py blockers              # All blocking tasks
-tasks.py blockers --person sarah  # Only blocking Sarah
-```
-
-### Extract from Meeting Notes
-```bash
-extract_tasks.py --from-text "Meeting: discuss Q1 planning, Sarah to own budget review"
-# Outputs: tasks.py add "Discuss Q1 planning" --priority medium
-#          tasks.py add "Sarah to own budget review" --owner sarah
-```
-
----
-
-## Priority Levels (Work)
-
-| Icon | Meaning | When to Use |
-|------|---------|-------------|
-| 🔴 **Q1** | Critical, blocking, deadline-driven | Revenue impact, blocking others |
-| 🟡 **Q2** | Important but not urgent | Reviews, feedback, planning |
-| 🟠 **Q3** | Waiting on external | Blocked by others |
-| 👥 **Team** | Monitor team tasks | Delegated, check-in only |
-| ⚪ **Backlog** | Someday/maybe | Low priority |
-
-## Priority Levels (Personal)
-
-| Icon | Meaning |
-|------|---------|
-| 🔴 **Must Do Today** | Non-negotiable today |
-| 🟡 **Should Do This Week** | Important, flexible timing |
-| 🟠 **Waiting On** | Blocked by others/external |
-| ⚪ **Backlog** | Someday/maybe |
-
----
-
-## Automation (Cron)
-
-Set up cron jobs for automated standups:
-
-| Job | Schedule | Command |
-|-----|----------|---------|
-| Daily Work Standup | Weekdays 8:30 AM | `python3 scripts/standup.py` |
-| Daily Personal Standup | Daily 8:00 AM | `python3 scripts/personal_standup.py` |
-| Weekly Review | Mondays 9:00 AM | `python3 scripts/weekly_review.py` |
-
-Example OpenClaw cron:
-```bash
-openclaw cron add \
-  --name "Daily Work Standup" \
-  --cron "30 8 * * 1-5" \
-  --tz "America/Los_Angeles" \
-  --session "isolated" \
-  --message "Run work standup" \
-  --channel "telegram:YOUR_GROUP_ID" \
-  --deliver
-```
-
----
-
-## Natural Language Triggers
-
-| You Say | Skill Does |
-|---------|-----------|
-| "daily standup" | Runs work standup, posts to channel |
-| "personal standup" | Runs personal standup, posts to channel |
-| "weekly review" | Runs weekly review, posts summary |
-| "what's on my plate?" | Lists all work tasks |
-| "personal tasks" | Lists all personal tasks |
-| "what's blocking Sarah?" | Shows tasks blocking Sarah |
-| "mark proposal done" | Completes matching work task |
-| "what's due this week?" | Lists work tasks due this week |
-| "add task: X" | Adds work task X |
-| "add personal task: X" | Adds personal task X |
-
----
-
-## Dataview Integration
-
-Add these queries to your Obsidian daily note template:
-
-### Today's Tasks
-
-```dataview
-TASK
-FROM "03-Areas/Work/Work Tasks.md"
-WHERE due = date("today")
-SORT due ASC
-LIMIT 10
-```
-
-### This Week
-
-```dataview
-TASK
-FROM "03-Areas/Work/Work Tasks.md"
-WHERE due > date("today") AND due <= date("today") + dur(7 days)
-SORT due ASC
-LIMIT 10
-```
-
-### Completed Today
-
-```dataview
-TASK
-FROM "03-Areas/Work/Work Tasks.md"
-WHERE completed AND due = date("today")
-SORT file.mtime DESC
-```
-
-**Note:** Adjust the `FROM` path to match your Obsidian vault structure.
-
----
-
-## Troubleshooting
-
-**"Tasks file not found"**
-```bash
-# Configure your paths
-export TASK_TRACKER_WORK_FILE="$HOME/path/to/Work Tasks.md"
-export TASK_TRACKER_PERSONAL_FILE="$HOME/path/to/Personal Tasks.md"
-```
-
-**Tasks not showing up**
-- Check task format uses `- [ ] **Task name**`
-- Verify section headers start with emoji: `## 🔴`, `## 🟡`, etc.
-- Run `tasks.py list` to debug parsing
-
-**Date filtering issues**
-- Due dates must use emoji format: `🗓️YYYY-MM-DD`
-- Examples: `🗓️2026-01-22`, `🗓️2026-12-31`
-
-**Dataview queries empty**
-- Install Dataview community plugin
-- Adjust `FROM` path to match your vault structure
-- Reload Obsidian after installing plugin
-
----
-
----
-
-## EOD Sync
-
-Auto-sync completed items from your daily note's `✅ Done` section into Weekly TODOs.
-
-### How It Works
-
-1. Reads today's daily note and extracts items from the `## ✅ Done` section
-2. Fuzzy-matches each completion against open `- [ ]` tasks in Weekly TODOs
-3. Marks matched tasks as `- [x] Task title ✅ YYYY-MM-DD`
-
-**Match thresholds:**
-- ≥ 80% similarity → auto-sync ✅
-- 60–79% → logged as uncertain ⚠️ (manual review needed)
-- < 60% → skipped ⏭️
-
-### Usage
+### Extraction and automation helpers
 
 ```bash
-# Preview what would change (safe, no writes)
+python3 scripts/extract_tasks.py --from-text "Meeting notes..."
+bash scripts/task-shortcuts.sh daily
+bash scripts/task-shortcuts.sh weekly
+bash scripts/task-shortcuts.sh done24h
+bash scripts/task-shortcuts.sh done7d
+```
+
+### EOD sync + weekly embed refresh
+
+```bash
 python3 scripts/eod_sync.py --dry-run
-
-# Run sync for today
 python3 scripts/eod_sync.py
-
-# Sync a specific day
-python3 scripts/eod_sync.py --date 2026-02-18
-
-# Verbose mode (shows all match scores)
-python3 scripts/eod_sync.py --verbose
-```
-
-### Embedded Daily Progress View
-
-Add a transclusion block to Weekly TODOs that embeds each day's `✅ Done` section inline in Obsidian:
-
-```bash
-# Preview what would be written (dry run)
 python3 scripts/update_weekly_embeds.py --dry-run
-
-# Refresh the 📊 Daily Progress section for the current week
 python3 scripts/update_weekly_embeds.py
-
-# Refresh for a specific week (pass any date in that week)
-python3 scripts/update_weekly_embeds.py --week 2026-02-17
 ```
 
-This inserts (or updates) a `## 📊 Daily Progress` section in Weekly TODOs:
+## Agent Invocation Guidance
 
-```markdown
-## 📊 Daily Progress
-
-### Monday
-![[01-TODOs/Daily/2026-02-17#✅ Done]]
-
-### Tuesday
-![[01-TODOs/Daily/2026-02-18#✅ Done]]
-...
-```
-
-> **Tip:** Run `update_weekly_embeds.py` at the start of each week to refresh the transclusion dates.
-
-### Required Environment Variables
+Use explicit, workspace-relative paths when running commands from agents:
 
 ```bash
-export TASK_TRACKER_WEEKLY_TODOS="$HOME/Obsidian/01-TODOs/Weekly TODOs.md"
-export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/Obsidian/01-TODOs/Daily"
+python3 <workspace>/<skill>/scripts/standup.py
+python3 <workspace>/<skill>/scripts/tasks.py list
 ```
 
----
+## References Index
 
-## Files
+Detailed docs moved to `references/`:
 
-| File | Purpose |
-|------|---------|
-| `scripts/tasks.py` | Main CLI - list, add, done, blockers (supports --personal) |
-| `scripts/standup.py` | Work daily standup generator |
-| `scripts/personal_standup.py` | Personal daily standup generator |
-| `scripts/weekly_review.py` | Weekly review generator |
-| `scripts/extract_tasks.py` | Extract tasks from meeting notes |
-| `scripts/eod_sync.py` | Auto-sync EOD completions to Weekly TODOs |
-| `scripts/update_weekly_embeds.py` | Refresh 📊 Daily Progress transclusion links |
-| `scripts/utils.py` | Shared utilities |
-| `assets/templates/` | Template task files |
+- `references/setup-and-config.md` — environment variables, defaults, setup flow
+- `references/commands.md` — command catalog and examples
+- `references/obsidian-and-dataview.md` — task structures, plugins, Dataview snippets
+- `references/eod-sync.md` — EOD sync + weekly transclusion behavior
+- `references/migration.md` — legacy migration and compatibility notes
+- `references/task-format.md` — legacy task format spec
 
----
+## Compatibility Notes
 
-## Migration from Legacy Format
-
-If you were using `~/clawd/memory/work/TASKS.md`:
-
-1. **Set environment variables** pointing to your new files
-2. **Convert dates** from `Due: ASAP` to `🗓️2026-01-22`
-3. **Convert sections** from `## High Priority` to `## 🔴 Q1: Do Now`
-4. **Remove inline metadata** - convert `  - Due: 2026-01-22` to `🗓️2026-01-22`
-
-The skill auto-detects format and falls back to legacy if Obsidian files don't exist.
+- Existing scripts/commands are preserved; this is a docs structure refactor.
+- Legacy file fallback (`TASK_TRACKER_LEGACY_FILE`) is still supported.
+- Migration guidance remains available in `references/migration.md`.

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,0 +1,69 @@
+# Command Reference
+
+Run from `<workspace>/<skill>`.
+
+## Core scripts
+
+```bash
+python3 scripts/tasks.py list
+python3 scripts/standup.py
+python3 scripts/personal_standup.py
+python3 scripts/weekly_review.py
+python3 scripts/extract_tasks.py --from-text "Meeting notes"
+```
+
+## Tasks CLI
+
+### List
+
+```bash
+python3 scripts/tasks.py list
+python3 scripts/tasks.py --personal list
+python3 scripts/tasks.py list --priority high
+python3 scripts/tasks.py list --due today
+python3 scripts/tasks.py list --due this-week
+python3 scripts/tasks.py blockers
+python3 scripts/tasks.py blockers --person sarah
+```
+
+### Add / Done
+
+```bash
+python3 scripts/tasks.py add "Draft project proposal" --priority high --due 2026-01-23
+python3 scripts/tasks.py --personal add "Call mom" --priority high --due 2026-01-22
+python3 scripts/tasks.py done "proposal"
+python3 scripts/tasks.py --personal done "call mom"
+```
+
+### State transitions
+
+```bash
+python3 scripts/tasks.py state pause "task title" --until 2026-03-01
+python3 scripts/tasks.py state delegate "task title" --to Alex --followup 2026-03-01
+python3 scripts/tasks.py state backlog "task title"
+python3 scripts/tasks.py state drop "task title"
+```
+
+### Backlog workflows
+
+```bash
+python3 scripts/tasks.py promote-from-backlog --cap 3
+python3 scripts/tasks.py review-backlog --stale-days 45 --json
+```
+
+### Standup/review extras
+
+```bash
+python3 scripts/standup.py --compact-json
+python3 scripts/tasks.py list --completed-since 24h
+python3 scripts/tasks.py list --completed-since 7d
+```
+
+## Wrapper shortcuts
+
+```bash
+bash scripts/task-shortcuts.sh daily
+bash scripts/task-shortcuts.sh weekly
+bash scripts/task-shortcuts.sh done24h
+bash scripts/task-shortcuts.sh done7d
+```

--- a/references/eod-sync.md
+++ b/references/eod-sync.md
@@ -1,0 +1,41 @@
+# EOD Sync and Weekly Embeds
+
+The EOD workflow syncs completed items from daily notes into Weekly TODOs.
+
+## Environment
+
+```bash
+export TASK_TRACKER_WEEKLY_TODOS="$HOME/path/to/Weekly TODOs.md"
+export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/path/to/Daily"
+```
+
+## EOD sync
+
+```bash
+python3 scripts/eod_sync.py --dry-run
+python3 scripts/eod_sync.py
+python3 scripts/eod_sync.py --date 2026-02-18
+python3 scripts/eod_sync.py --verbose
+```
+
+Behavior:
+
+- Reads `## ✅ Done` from the selected daily note
+- Fuzzy-matches against open tasks in weekly TODOs
+- Marks matched items complete as `- [x] ... ✅ YYYY-MM-DD`
+
+Match thresholds:
+
+- `>= 80%`: auto-sync
+- `60-79%`: uncertain, manual review
+- `< 60%`: skipped
+
+## Weekly transclusion refresh
+
+```bash
+python3 scripts/update_weekly_embeds.py --dry-run
+python3 scripts/update_weekly_embeds.py
+python3 scripts/update_weekly_embeds.py --week 2026-02-17
+```
+
+This refreshes the `## 📊 Daily Progress` section in Weekly TODOs with Obsidian transclusion links.

--- a/references/migration.md
+++ b/references/migration.md
@@ -1,0 +1,31 @@
+# Migration and Legacy Compatibility
+
+This skill still supports legacy workflows while preferring env-configured file paths.
+
+## Legacy support preserved
+
+- `TASK_TRACKER_LEGACY_FILE` fallback is still supported.
+- Existing command names and scripts are unchanged.
+
+## Suggested migration flow
+
+1. Set env vars for your current work/personal markdown files.
+2. Keep legacy file available during transition.
+3. Normalize task date/style gradually.
+4. Validate with list + standup + weekly review commands.
+
+## Migrating from `~/clawd/memory/work/TASKS.md`
+
+- Set `TASK_TRACKER_WORK_FILE` and (if needed) `TASK_TRACKER_PERSONAL_FILE`
+- Convert old date markers like `Due: ASAP` to your preferred supported format
+- Move old section naming toward Q1/Q2/Q3/backlog structure if useful
+
+## Verification checklist
+
+```bash
+python3 scripts/tasks.py list
+python3 scripts/standup.py
+python3 scripts/weekly_review.py
+```
+
+If output looks correct, migration is complete.

--- a/references/obsidian-and-dataview.md
+++ b/references/obsidian-and-dataview.md
@@ -1,0 +1,66 @@
+# Obsidian and Dataview
+
+Task-tracker works with plain markdown files and is commonly used with Obsidian.
+
+## Recommended plugins
+
+- Dataview (recommended for dashboard queries)
+- Tasks plugin (optional, richer metadata)
+- Templater + Periodic Notes (optional)
+
+## Supported task styles
+
+1. Tasks-plugin style (with `📅`, `🔺`, `✅` markers)
+2. Legacy/dataview-style markdown fields (`🗓️`, `area::`, etc.)
+
+See `references/task-format.md` for low-level legacy field examples.
+
+## Example sections
+
+Work-style sections usually map to:
+
+- `## 🔴 Q1: Do Now`
+- `## 🟡 Q2: Schedule`
+- `## 🟠 Q3: Waiting`
+- `## 👥 Team Tasks`
+- `## ⚪ Q4: Backlog`
+
+Personal-style sections usually map to:
+
+- `## 🔴 Must Do Today`
+- `## 🟡 Should Do This Week`
+- `## 🟠 Waiting On`
+- `## ⚪ Backlog`
+
+## Dataview snippets
+
+Adjust paths to your vault layout.
+
+### Due today
+
+```dataview
+TASK
+FROM "03-Areas/Work/Work Tasks.md"
+WHERE due = date("today")
+SORT due ASC
+LIMIT 10
+```
+
+### Due this week
+
+```dataview
+TASK
+FROM "03-Areas/Work/Work Tasks.md"
+WHERE due > date("today") AND due <= date("today") + dur(7 days)
+SORT due ASC
+LIMIT 10
+```
+
+### Completed today
+
+```dataview
+TASK
+FROM "03-Areas/Work/Work Tasks.md"
+WHERE completed AND due = date("today")
+SORT file.mtime DESC
+```

--- a/references/setup-and-config.md
+++ b/references/setup-and-config.md
@@ -1,0 +1,56 @@
+# Setup and Configuration
+
+This skill is environment-first: configure file paths with env vars, then run scripts.
+
+## Required
+
+```bash
+export TASK_TRACKER_WORK_FILE="$HOME/path/to/Work Tasks.md"
+```
+
+For personal commands (`--personal`), also set:
+
+```bash
+export TASK_TRACKER_PERSONAL_FILE="$HOME/path/to/Personal Tasks.md"
+```
+
+## Optional
+
+```bash
+export TASK_TRACKER_ARCHIVE_DIR="$HOME/path/to/archive"
+export TASK_TRACKER_LEGACY_FILE="$HOME/path/to/TASKS.md"
+export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/path/to/Daily"
+export TASK_TRACKER_WEEKLY_TODOS="$HOME/path/to/Weekly TODOs.md"
+```
+
+## Defaults
+
+If env vars are not set, task-tracker falls back to:
+
+- Work: `~/Obsidian/03-Areas/Work/Work Tasks.md`
+- Personal: `~/Obsidian/03-Areas/Personal/Personal Tasks.md`
+- Legacy: `~/clawd/memory/work/TASKS.md`
+
+Defaults are convenient but user-specific; explicit env vars are recommended.
+
+## Run location
+
+```bash
+cd <workspace>/<skill>
+# Example: cd ~/projects/skills/shared/task-tracker
+```
+
+Then run scripts with `python3 scripts/...`.
+
+## Troubleshooting
+
+### "Tasks file not found"
+- Verify `TASK_TRACKER_WORK_FILE` and/or `TASK_TRACKER_PERSONAL_FILE`
+- Confirm files exist and are readable
+
+### Tasks not appearing
+- Check markdown checkbox format: `- [ ]`
+- Verify expected section headers in your task file
+
+### Date filtering issues
+- Use supported due date formats for your chosen task syntax (see `task-format.md` and `obsidian-and-dataview.md`)


### PR DESCRIPTION
## Summary
Refactor docs to follow Skillcraft conventions while preserving command compatibility and behavior.

### What changed
- Trimmed `SKILL.md` into a lean entrypoint with:
  - frontmatter
  - when-to-use triggers
  - quick start
  - core commands
  - references index
- Moved deeper content into new `references/` docs:
  - `setup-and-config.md`
  - `commands.md`
  - `obsidian-and-dataview.md`
  - `eod-sync.md`
  - `migration.md`
- Updated `README.md` to be a doc map + concise quick start, avoiding duplication with `SKILL.md`.
- Normalized path guidance toward env-first setup and `<workspace>/<skill>` notation.

## Skillcraft compliance
- **Lean SKILL entrypoint:** reduced from 535 lines to 149 lines.
- **Detail moved to references:** deep setup/how-to/migration content now lives under `references/`.
- **Compatibility preserved:** no scripts/commands removed; legacy migration path documented in `references/migration.md`.
- **Reference integrity:** SKILL references verified present under `references/`.

## Validation
- Tests: `pytest -q`
  - Result: `105 passed in 0.35s`
- Link/reference check:
  - Verified all files referenced in `SKILL.md` exist in `references/`.
- Codex review gate:
  - Ran `codex review --base main`
  - Result: no P0/P1/P2 findings (no actionable issues reported).

## Notes
Docs-only refactor; no runtime code behavior changed.
