### PR TITLE
refactor(tasks): consolidate parser and mutation boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ python3 scripts/weekly_review.py
 - Weekly review + archive workflows (`weekly_review.py`, `archive.py`)
 - Backlog and delegated-task hygiene
 - Action extraction from notes (`extract_tasks.py`)
-- End-of-day sync helpers retained as legacy workflows
+- End-of-day evidence reporting retained, with legacy Weekly TODO writes behind `--apply`
 - Weekly transclusion refresh for Obsidian (`update_weekly_embeds.py`)
 
 ## Compatibility
@@ -47,6 +47,8 @@ python3 scripts/weekly_review.py
 Active task mutations now require canonical `task_id::` values. Legacy title
 matching remains useful for read-only review and migration diagnostics, but
 write paths block when they cannot resolve exactly one canonical task.
+Fallback IDs may appear in JSON output for diagnostics; they are not valid
+mutation targets.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when the user asks to:
 - Add, list, update, or complete tasks
 - Check blockers or due dates
 - Extract actions from meeting notes
-- Sync completed daily items to weekly todos
+- Report completed daily items against weekly todos without changing canonical task state
 
 ## Quick Start
 
@@ -118,6 +118,7 @@ bash scripts/task-shortcuts.sh tasks     # quick priorities view
 ```bash
 python3 scripts/eod_sync.py --dry-run
 python3 scripts/eod_sync.py
+python3 scripts/eod_sync.py --apply   # legacy Weekly TODO checkbox write only
 python3 scripts/update_weekly_embeds.py --dry-run
 python3 scripts/update_weekly_embeds.py
 ```
@@ -144,6 +145,7 @@ Detailed docs moved to `references/`:
 
 ## Compatibility Notes
 
-- Existing scripts/commands are preserved; this is a docs structure refactor.
+- Active task mutations require canonical `task_id::` values; fallback IDs are diagnostics only.
+- `scripts/eod_sync.py` is report-only by default. `--apply` is a legacy Weekly TODO checkbox helper and does not complete canonical tasks.
 - Legacy file fallback (`TASK_TRACKER_LEGACY_FILE`) is still supported.
 - Migration guidance remains available in `references/migration.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,8 @@ graph TD
         TL["task_ledger.py"]
         TR["task_repair.py"]
         TT["task_transitions.py"]
+        REC["task_records.py"]
+        LINES["task_lines.py"]
         SC["standup_common.py"]
     end
 
@@ -54,7 +56,9 @@ graph TD
     TASKS --> TL
     TASKS --> TR
     TASKS --> TT
+    TASKS --> REC
     STANDUP --> UTILS
+    STANDUP --> REC
     STANDUP --> DN
     STANDUP --> SC
     PSTANDUP --> UTILS
@@ -74,6 +78,8 @@ graph TD
     TL -->|append| LEDGER
     TR -->|repair IDs| WT
     TT -->|ID mutations| WT
+    REC -->|shared parsed record| UTILS
+    TT --> LINES
     DN -->|read| DAILY
     WEEKLY -->|write| ARCHIVE
 
@@ -268,7 +274,10 @@ sequenceDiagram
 | | `--due YYYY-MM-DD` | Set due date |
 | | `--owner NAME` | Assign owner |
 | | `--area CATEGORY` | Set area/category |
-| `done "query"` | | Fuzzy-match and complete a task |
+| `done "task_id"` | | Complete exactly one active task by canonical ID |
+| `identity-audit` | | Report missing, duplicate, and malformed task IDs without writing |
+| `identity-repair` | `--apply` | Add safe missing `task_id::` metadata |
+| `ingest-daily-log` | `--file PATH` | Report completion evidence links; no task writes |
 | `blockers` | `--person NAME` | Show blocking tasks |
 | `archive` | | Archive done tasks to quarterly file |
 
@@ -330,6 +339,8 @@ sequenceDiagram
 | `tasks.py list` | Task board | — |
 | `tasks.py add` | Task board | Task board (insert line) |
 | `tasks.py done` | Task board, daily notes | Task board (remove/update line), daily note (append) |
+| `tasks.py identity-audit` | Task board | — |
+| `tasks.py ingest-daily-log` | Task board, done text | — |
 | `tasks.py archive` | Daily notes | Quarterly archive |
 | `standup.py` | Task board, daily notes, calendar | — |
 | `personal_standup.py` | Task board, daily notes, calendar | — |
@@ -342,6 +353,8 @@ sequenceDiagram
 - `log_done.py` is append-only — never overwrites existing data
 - Archive operations are idempotent — skip entries already present
 - Priority escalation is read-only — task files are never mutated for display
+- Fuzzy/title evidence is read-only by default and cannot complete canonical tasks
+- Fallback IDs in JSON are diagnostics only; writes require `task_id::` or readable legacy `id::`
 
 ---
 
@@ -349,7 +362,7 @@ sequenceDiagram
 
 ### Calendar (gog CLI)
 
-`standup_common.py` calls `gog calendar list <calendar_id> --account <account> --today --json` for each configured calendar. Configured via `STANDUP_CALENDARS` env var (JSON object keyed by label). Silently skipped if `gog` is unavailable or config is unset.
+`standup_common.py` calls `gog calendar list <calendar_id> --account <account> --today --json` for each configured calendar. Configured via `STANDUP_CALENDARS` env var (JSON object keyed by label). Silently skipped if `gog` is unavailable or config is unset. Calendar data is evidence/display input only; it does not mutate task truth.
 
 ### Telegram (task-shortcuts.sh)
 

--- a/docs/CALENDAR_INTEGRATION.md
+++ b/docs/CALENDAR_INTEGRATION.md
@@ -1,6 +1,8 @@
 # Calendar Integration
 
 The daily standup script can optionally fetch today's calendar events via the `gog` CLI.
+Calendar data is display/evidence input only. It must not complete, reschedule,
+or otherwise mutate canonical task state.
 
 ## Configuration
 
@@ -48,10 +50,11 @@ export STANDUP_CALENDARS='{
 - Shows events in chronological order
 - Silently skips calendars that fail to fetch
 - If `STANDUP_CALENDARS` is not set, no calendar integration (script works without it)
+- Does not write task board state; task completion still requires `tasks.py done <task_id>`
 
 ## Example Output
 
-```
+```text
 📋 Daily Standup — Wednesday, January 21
 
 📅 Today's Calendar:

--- a/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
+++ b/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
@@ -1,0 +1,467 @@
+---
+title: refactor: consolidate task parser and mutation boundary
+type: refactor
+status: active
+date: 2026-05-21
+origin: docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
+---
+
+# refactor: consolidate task parser and mutation boundary
+
+## Summary
+
+Build PR #108B as the immediate follow-up to the merged canonical identity kernel. The goal is to make every task-tracker read surface consume one canonical active-task record model and make every active-board write route through the ID-only mutation kernel. This PR should not add the completion inbox, Gmail/calendar/session evidence, or broad state transitions.
+
+**Target repo:** task-tracker-openclaw-skill. Unless explicitly prefixed with another repo alias, paths in this plan are relative to this repo.
+
+---
+
+## Problem Frame
+
+PR #108A landed the correct foundation: inline `task_id::` metadata, identity audit/repair, ID-only `done`, and a minimal append-only ledger. The next risk is that the repository still contains multiple ways to interpret a task and multiple adjacent ways to make completion-like changes.
+
+The clearest duplicate model is in `scripts/tasks.py`: primitive summaries build fallback IDs and canonical task dictionaries through `_build_task_catalog()`, `_task_identifier_bundle()`, and `_canonical_task()`, while `scripts/task_identity.py` separately exposes `IdentityRecord`, active-record filtering, fallback IDs, and canonical ID source semantics. Standup and weekly review still operate mostly on raw `parse_tasks()` dictionaries, and `scripts/eod_sync.py` still fuzzy-matches daily-note Done lines to weekly TODO lines and writes checked boxes by default.
+
+That means 108A made the core safer, but the surrounding workflow code can still teach agents and users the wrong model. PR #108B should collapse those seams before evidence candidates or UX automation are expanded.
+
+---
+
+## Requirements
+
+- R1. There must be one documented active-task read contract used by identity audit, primitive summaries, standup, and weekly review surfaces.
+- R2. Canonical identity fields must have the same meaning everywhere: `task_id::` first, legacy `id::` readable as compatibility, fallback IDs diagnostic only, and fallback IDs never valid write targets.
+- R3. No active-board mutation path may resolve a task by title, fuzzy title score, list position, generated fallback ID, or current parse order.
+- R4. All active-board completion writes must route through the ID-only kernel in `scripts/task_transitions.py`.
+- R5. Duplicate task-line removal/replacement helpers must be removed from public workflow code or centralized behind a line-number-verified kernel helper.
+- R6. Standup and weekly review JSON primitives must emit stable canonical IDs where available and explicit `missing_task_id`/`fallback_only` diagnostics where not.
+- R7. Daily-log and EOD completion parsing may produce evidence diagnostics or suggestions, but this PR must not auto-complete active tasks from title or fuzzy matches.
+- R8. Legacy EOD sync behavior must be made visibly legacy and non-default, or changed to dry-run/report-only until the evidence inbox PR defines confirmation semantics.
+- R9. Calendar helper output may classify meetings, but it must not mutate task truth or imply calendar status owns task state.
+- R10. Public docs and command help must explain that 108B is parser/mutation consolidation, not the full vNext standup or evidence inbox.
+
+**Origin traceability:** This plan implements the 108A follow-up explicitly named as "PR #108B: consolidate parser and mutation boundaries around one `TaskRecord` contract and remove duplicate task-line mutation helpers" in `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`.
+
+---
+
+## Scope Boundaries
+
+- Do not introduce completion candidates in this PR.
+- Do not add Gmail, calendar, session-log, or Telegram DONE ingestion beyond read-only evidence diagnostics already present.
+- Do not add first-class backlog/delegated/frozen/drop state transitions.
+- Do not make JSONL ledger replay the source of current task truth.
+- Do not redesign the daily standup or weekly review UX caps here; this PR only makes their task identity source coherent.
+- Do not update Lobster cron workflows here. They should integrate after the task-tracker command contract is stable.
+- Do not preserve fuzzy auto-mutation for compatibility if it can write task state without a canonical ID.
+
+### Deferred to Follow-Up Work
+
+- PR #108C: evidence inbox that creates suggestions only and applies confirmed items through ID-only `done`.
+- Later workflow PR: wire Lobster standup, Telegram DONEs, weekly review, and cron flows to canonical IDs.
+- Later UX PR: capped daily/EOD decision briefs, stale-task audits, freeze box, and proactive completion prompts.
+- Later product slice: backlog/delegation/frozen states with a real state-transition contract.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/utils.py` is still the markdown parser source. It returns raw dictionaries grouped into legacy sections and already parses `task_id::`, legacy `id::`, line numbers, due dates, recurrence, owner, area, and objective metadata.
+- `scripts/task_identity.py` has the strongest current identity contract through `IdentityRecord`, `task_records()`, `active_records()`, `fallback_id_for()`, `export_active()`, and `audit_identity()`.
+- `scripts/task_transitions.py` has the ID-only mutation kernel through `complete_by_id()`, line-number-verified `_remove_task_line()`, recurrence rollover, ledger preflight, daily-log write, and rollback on ledger append failure.
+- `scripts/tasks.py` still builds a second task catalog for primitive summaries and daily-log ingestion. It generates slug/index fallback IDs, matches exact titles, accepts fuzzy matches, and emits auto-link decisions from `_ingest_match_line()`.
+- `scripts/standup.py` loads raw parser dictionaries, uses `regroup_by_effective_priority()`, and emits compact JSON with generated quick IDs instead of canonical task IDs.
+- `scripts/weekly_review.py` loads raw parser dictionaries, archives stale checked board items, and removes stale board lines through string replacement.
+- `scripts/eod_sync.py` is explicitly documented as fuzzy auto-sync and writes `[x]` lines by default unless `--dry-run` is passed.
+- `scripts/archive.py` and `scripts/tasks.py` both contain `_remove_task_line()` helpers separate from the line-number-verified helper in `scripts/task_transitions.py`.
+- `tests/test_task_identity.py`, `tests/test_task_primitives.py`, `tests/test_objective_parser.py`, `tests/test_standup_compact.py`, `tests/test_eod_sync.py`, and `tests/test_task_transitions.py` are the relevant regression surfaces.
+
+### Institutional Learnings
+
+- The vNext requirements in `lobster-workflows:docs/brainstorms/2026-05-20-task-tracker-vnext-requirements.md` require canonical owner clarity, read-only audit versus metadata repair separation, direct ID-based DONE semantics, and a hard ban on title/list-position mutation.
+- The failure diagnosis in `lobster-workflows:docs/debug/2026-05-20-task-tracker-ux-failures.md` identifies duplicate entries, missed DONEs, stale carryover, and noisy standups as source-of-truth failures.
+- The radical simplification ideation in `lobster-workflows:docs/ideation/2026-05-20-task-tracker-radical-simplification-ideas.md` recommends one active board, durable IDs, one DONE pipeline, an audit ledger, and evidence-only external signals.
+- Oracle's architecture review recommended landing 108A as a reduced identity kernel, then immediately doing 108B as single parser contract and compatibility cleanup before reintroducing completion evidence.
+
+### External References
+
+No external research is needed. The hard part is local boundary cleanup, not library or API behavior.
+
+---
+
+## Key Technical Decisions
+
+- Use the existing parser as the markdown grammar owner. Do not create a second markdown parser; wrap `parse_tasks()` output into a typed canonical record model.
+- Move the shared read contract into `scripts/task_records.py`. `scripts/task_identity.py` should become an audit/export consumer of that contract rather than the owner of a parallel identity model.
+- Move line-number-verified task-line edit helpers into a small low-level text module, likely `scripts/task_lines.py`, so completion, archive cleanup, and stale checked-line cleanup do not import private helpers from workflow code.
+- Keep fallback IDs visible only for audit and diagnostics. If a caller wants to write, it must use a real `task_id::` or legacy `id::` that resolves to exactly one active task.
+- Treat daily-log ingestion and EOD sync as evidence producers, not mutation surfaces. Fuzzy matching may rank suggestions; it must not write task state.
+- Keep the board as current-state truth and the ledger as audit history. This PR should not expand ledger semantics into replay or projection.
+- Prefer compatibility by making unsafe commands report clear blocked/degraded output over silently preserving unsafe writes.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+flowchart TD
+    Board["Markdown task board"] --> Parser["utils.parse_tasks()"]
+    Parser --> Records["task_records.TaskRecord"]
+
+    Records --> Identity["identity audit / repair"]
+    Records --> Primitives["tasks.py JSON primitives"]
+    Records --> Standup["standup output"]
+    Records --> Weekly["weekly review output"]
+    Records --> Evidence["daily-log / EOD evidence reports"]
+
+    Records --> Resolver["resolve exactly one canonical ID"]
+    Resolver --> Mutations["task_transitions.complete_by_id()"]
+    Mutations --> Lines["task_lines line-number edits"]
+    Lines --> Board
+    Mutations --> Ledger["JSONL audit ledger"]
+    Mutations --> DailyLog["daily completion log"]
+
+    Evidence -. "suggestions only" .-> Resolver
+```
+
+The important boundary is that read surfaces may consume fallback diagnostics, but write surfaces only accept a canonical ID that resolves to one active record. Evidence surfaces can suggest a match; they cannot write task state.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should 108B be another broad UX/workflow PR? No. It is a consolidation PR between the landed kernel and future evidence inbox.
+- Should standup and weekly review move to a database-backed model now? No. They should consume one parser-backed task record while Obsidian markdown remains current state.
+- Should fuzzy matching disappear completely? No. It can stay for suggestion ranking and diagnostics, but not as a write target.
+- Should fallback IDs be removed from outputs? No. They are useful for diagnostics and duplicate census, but outputs must label them as fallback-only and non-mutating.
+
+### Deferred to Implementation
+
+- Exact compatibility behavior for `scripts/eod_sync.py`. The implementer should pick the smallest public behavior change that prevents fuzzy auto-mutation by default and makes legacy risk painfully visible.
+- Exact output field names for warnings. Preserve existing schemas where possible, but add explicit diagnostics rather than hiding missing IDs.
+
+---
+
+## Implementation Units
+
+### U1. Characterize Current Parser and Write Behavior
+
+**Goal:** Lock down the behaviors that must survive the refactor and expose the unsafe write behaviors that 108B must change.
+
+**Requirements:** R1, R2, R3, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `tests/test_task_identity.py`
+- Modify: `tests/test_task_primitives.py`
+- Modify: `tests/test_objective_parser.py`
+- Modify: `tests/test_standup_compact.py`
+- Modify: `tests/test_eod_sync.py`
+- Modify: `tests/test_task_transitions.py`
+
+**Approach:**
+
+- Add characterization tests before moving parser plumbing.
+- Capture current support for Obsidian, legacy, objectives, plain task lines, bold task lines, subtasks, parking lot exclusion, `task_id::`, and legacy `id::`.
+- Add failing tests for current duplicate model problems: primitive summaries and identity audit should agree on canonical ID, identity source, line number, section, title, area, and missing-ID diagnostics.
+- Add tests proving fallback IDs are diagnostic and rejected for mutation.
+- Add tests around EOD sync/default behavior so the implementation can safely change auto-write semantics.
+
+**Execution note:** Characterization-first. Add the regression tests that describe today's parser and write boundaries before moving shared record or line-edit helpers.
+
+**Test scenarios:**
+
+- A task with `task_id::tsk_example` has the same canonical ID in identity audit, standup summary, weekly summary, and task primitive catalog output.
+- A task with only legacy `id::legacy_example` is readable as compatibility but docs/output identify that it is not newly repaired metadata.
+- A task without an ID appears as `missing_task_id` and `fallback_only` in read surfaces.
+- Two tasks with the same title remain distinct by line and canonical ID in read surfaces.
+- Passing a fallback/generated ID to `tasks.py done` returns an unsafe or resolution-failed error with no board write.
+- `eod_sync.py` no longer writes weekly TODO completion by default from a fuzzy match.
+
+**Verification:**
+
+- The initial tests make the refactor target observable before implementation rearranges modules.
+
+### U2. Introduce One Shared `TaskRecord` Read Contract
+
+**Goal:** Replace ad hoc canonical-task dictionaries with one shared record shape built from `parse_tasks()` output.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** U1
+
+**Files:**
+
+- Create: `scripts/task_records.py`
+- Modify: `scripts/task_identity.py`
+- Modify: `scripts/utils.py`
+- Test: `tests/test_task_identity.py`
+- Test: `tests/test_objective_parser.py`
+
+**Approach:**
+
+- Introduce a small dataclass or typed record that captures parser fields plus identity fields: canonical ID, identity source, fallback ID, title, done, section, area/department, priority, due, owner, goal, recurrence, raw line, and line number.
+- Build records from `utils.parse_tasks()` so `scripts/utils.py` remains the only markdown grammar parser.
+- Reuse or move `fallback_id_for()`, `opaque_task_id()`, `TASK_ID_RE`, and `LEGACY_ID_RE` so identity audit and other consumers share the same interpretation.
+- Preserve parking-lot exclusion and active-record filtering semantics from `scripts/task_identity.py`.
+- Add a serializer for read surfaces that includes `task_id`, `identity_source`, `fallback_id`, `missing_task_id`, and `fallback_only`.
+
+**Test scenarios:**
+
+- Parsed task metadata from Obsidian format survives conversion into `TaskRecord`.
+- Objectives-format parent/child metadata survives conversion without losing `parent_objective` and `is_objective` behavior needed by existing objective tests.
+- Parking-lot tasks are excluded from active records but still parseable when all records are requested.
+- Malformed `task_id::` remains visible to identity audit.
+- Fallback IDs are deterministic for the same raw line and line number.
+
+**Verification:**
+
+- Identity audit and existing parser tests pass while using the shared record contract internally.
+
+### U3. Migrate Primitive Summaries to Shared Records
+
+**Goal:** Make `tasks.py standup-summary`, `weekly-review-summary`, `calendar-sync`, and `ingest-daily-log` consume the shared task record catalog instead of building their own identity model.
+
+**Requirements:** R1, R2, R3, R6, R9
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `scripts/tasks.py`
+- Modify: `scripts/task_identity.py`
+- Test: `tests/test_task_primitives.py`
+- Test: `tests/test_task_identity.py`
+
+**Approach:**
+
+- Replace `_build_task_catalog()`, `_task_identifier_bundle()`, `_canonical_task()`, `_task_id_lookup()`, and `_canonical_task_with_lookup()` with shared-record helpers.
+- Preserve the primitive JSON schema where callers depend on it, but add explicit identity diagnostics for fallback-only rows.
+- Ensure `calendar-sync` reports meeting tasks from shared records and remains a read-only helper.
+- Keep daily-log ingestion as parsing and matching output only; it should produce evidence-like diagnostics, not a command that claims completion state changed.
+
+**Test scenarios:**
+
+- `standup-summary` and `weekly-review-summary` emit the same canonical ID for the same task.
+- Duplicate titles with real canonical IDs stay distinct and stable in both summaries.
+- Missing-ID tasks include `missing_task_id: true` and `fallback_only: true`.
+- `calendar-sync` includes canonical IDs when available and warnings/diagnostics when IDs are missing.
+- `ingest-daily-log` exact-ID matches point to canonical IDs from the shared record model.
+- `ingest-daily-log` exact-title and fuzzy matches are marked as suggestions or needs-review, not auto-mutation instructions.
+
+**Verification:**
+
+- Primitive summary tests pass without any local fallback-ID generator in `scripts/tasks.py`.
+
+### U4. Migrate Standup and Weekly Review Read Paths
+
+**Goal:** Make user-facing standup and weekly review outputs use the same task identity contract as primitive summaries.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- Modify: `scripts/standup.py`
+- Modify: `scripts/weekly_review.py`
+- Modify: `scripts/utils.py`
+- Test: `tests/test_standup_compact.py`
+- Test: `tests/test_objective_parser.py`
+- Test: `tests/test_task_primitives.py`
+
+**Approach:**
+
+- Keep the existing human-readable output shape where possible, but feed active task groups from shared records or record-derived dictionaries.
+- Update compact standup JSON so task rows include canonical `task_id` when available rather than only quick IDs.
+- Keep `quick_id` only as a display/session convenience if needed; it must not be documented as a mutation target.
+- Ensure weekly review grouping, overdue calculations, and objective progress keep their existing semantics while using the shared read contract.
+
+**Test scenarios:**
+
+- Compact standup `dos` rows include canonical task IDs for tasks with `task_id::`.
+- Compact standup rows with missing IDs include fallback diagnostics and do not present quick IDs as write targets.
+- Weekly review `DO` rows match primitive summary identity fields for the same active tasks.
+- Objective-format tasks still populate legacy priority buckets and objective progress after record conversion.
+- Existing escalation, due-today, recurrence suffix, and grouping behavior remains unchanged.
+
+**Verification:**
+
+- Standup and weekly review consume one task identity model without product UX redesign.
+
+### U5. Centralize Active-Board Line Mutation Helpers
+
+**Goal:** Remove duplicate board-line mutation helpers from workflow surfaces and keep active-board edits behind line-number-verified kernel helpers.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `scripts/task_transitions.py`
+- Create: `scripts/task_lines.py`
+- Modify: `scripts/tasks.py`
+- Modify: `scripts/archive.py`
+- Modify: `scripts/weekly_review.py`
+- Test: `tests/test_task_transitions.py`
+- Test: `tests/test_objective_parser.py`
+- Test: `tests/test_archive.py`
+
+**Approach:**
+
+- Move line-number-verified task-line removal/replacement into a low-level helper module that has no dependency on CLI, ledger, daily notes, standup, or weekly review code.
+- Remove `scripts/tasks.py` string/index-based `_remove_task_line()` from public import paths.
+- Update stale checked-line cleanup in archive/weekly code to use stable line-number matching when it truly needs to remove board lines.
+- If a cleanup path cannot resolve a checked line by stable line number and raw line, it should skip and warn rather than string-replace the first matching title/line.
+
+**Test scenarios:**
+
+- Removing a parent task still removes indented continuation/subtask lines.
+- Removing one duplicate-title task removes only the line resolved by line number and raw line.
+- A stale checked board cleanup skips with a warning when the raw line no longer matches its parsed line number.
+- No test imports `_remove_task_line` from `scripts/tasks.py`; tests import the shared/internal helper instead.
+
+**Verification:**
+
+- There is one active-board line mutation implementation used by completion and cleanup paths.
+
+### U6. Make EOD Sync and Daily-Log Matching Evidence-Only
+
+**Goal:** Stop fuzzy/title completion evidence from mutating task truth before the evidence inbox exists.
+
+**Requirements:** R3, R7, R8
+
+**Dependencies:** U3, U5
+
+**Files:**
+
+- Modify: `scripts/eod_sync.py`
+- Modify: `scripts/tasks.py`
+- Modify: `scripts/daily_notes.py`
+- Test: `tests/test_eod_sync.py`
+- Test: `tests/test_task_primitives.py`
+- Test: `tests/test_done_scan_daily_links.py`
+
+**Approach:**
+
+- Change `scripts/eod_sync.py` so the safe default is report-only. If legacy write behavior is retained, put it behind an explicit flag with warning text that says it is a legacy fuzzy write path and not canonical task completion.
+- Keep fuzzy scoring and normalization tests because they are useful for future evidence suggestions.
+- Ensure `tasks.py ingest-daily-log` output never implies that `auto-link` has completed a task. Rename decisions or add fields if needed so exact-ID matches are still just evidence links.
+- Confirm that the only command applying completion remains `tasks.py done <canonical-id>`.
+
+**Test scenarios:**
+
+- Running `eod_sync.py` without an apply flag leaves the weekly TODO file unchanged even for high-confidence matches.
+- Running any retained legacy apply mode requires an explicit flag and emits a warning that it does not update canonical task state.
+- `ingest-daily-log` fuzzy matches return suggestion/needs-review metadata and do not write the active board, daily notes, or ledger.
+- Exact canonical ID evidence links are represented as high-confidence evidence, not direct mutations.
+- The board content and ledger content are byte-identical before and after ingestion/report-only commands.
+
+**Verification:**
+
+- There is no fuzzy/title write path left in the default command surface.
+
+### U7. Update Docs, Help, and Migration Notes
+
+**Goal:** Make the public surface teach the new contract accurately.
+
+**Requirements:** R2, R3, R8, R10
+
+**Dependencies:** U3, U4, U5, U6
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/CALENDAR_INTEGRATION.md`
+- Modify: `scripts/tasks.py`
+- Test: `scripts/ci/check-public-hygiene.sh`
+
+**Approach:**
+
+- Document the 108B contract: one parser-backed task record, canonical IDs for writes, fallback IDs diagnostics only, fuzzy evidence report-only.
+- Remove or rewrite command examples that suggest `done` by title, quick ID, fallback ID, or fuzzy EOD sync.
+- Make `eod_sync.py` documentation visibly legacy if retained.
+- Add a brief migration note: run identity audit/repair before expecting standup/weekly IDs to be complete.
+
+**Test scenarios:**
+
+- Public docs describe `tasks.py done <task_id>` as the only completion mutation.
+- Public docs do not list fuzzy EOD sync as a default automation that marks canonical tasks done.
+- Help text for ingestion/EOD paths uses evidence/report language rather than completion mutation language.
+- Public hygiene checks pass.
+
+**Verification:**
+
+- A user or agent reading docs/help cannot reasonably infer that title/fuzzy matching is a safe write path.
+
+---
+
+## System-Wide Impact
+
+- **User trust:** Standup and weekly output become less magical and more explicit about whether a task has a durable ID.
+- **Agent behavior:** Agents get one canonical ID field to carry through standup, weekly review, and direct DONE commands.
+- **Workflow safety:** EOD and daily-log parsing stop competing with the ID-only kernel.
+- **Compatibility:** Existing read/report commands should keep broadly similar output, but unsafe default write behavior may be blocked or moved behind explicit legacy flags.
+- **Future sequencing:** 108C can build an evidence inbox on top of shared records instead of inheriting current fuzzy write ambiguity.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Record-model refactor breaks objectives-format behavior | Add characterization coverage before changing internals and keep `utils.parse_tasks()` as grammar owner. |
+| Existing automation expects EOD sync to write by default | Make the behavior change explicit in docs/help and keep a consciously named legacy apply flag only if necessary. |
+| Output schema changes break Lobster consumers | Preserve existing fields where possible and add identity diagnostics rather than renaming stable fields casually. |
+| Shared helper placement creates circular imports | Keep pure read helpers in `scripts/task_records.py` and pure line-edit helpers in `scripts/task_lines.py`, with workflow modules depending downward. |
+| Fallback IDs leak back into mutation commands | Test `done <fallback-id>` and duplicate-title cases explicitly. |
+
+---
+
+## Phased Delivery
+
+1. Add characterization tests for current parser, identity, primitive, standup, weekly, EOD, and mutation behavior.
+2. Introduce the shared task record contract and migrate identity audit to it.
+3. Migrate `tasks.py` primitive summary and evidence parsing helpers.
+4. Migrate standup and weekly review read paths.
+5. Centralize active-board line mutation helpers.
+6. Make EOD/daily-log fuzzy matching report-only by default.
+7. Update docs/help and run the full local verification suite.
+
+---
+
+## Documentation Plan
+
+- Update `README.md` and `SKILL.md` to describe the stable command contract after 108B.
+- Update `docs/ARCHITECTURE.md` so diagrams and prose show shared parser/record flow rather than parallel identity models.
+- Update `docs/CALENDAR_INTEGRATION.md` if it implies calendar status can mutate task truth.
+- Keep the broader vNext requirements in the Lobster docs as product direction, not as a claim that 108B delivers the complete UX.
+
+---
+
+## Verification Strategy
+
+- Run `pytest -q tests/test_task_identity.py tests/test_objective_parser.py tests/test_task_primitives.py tests/test_standup_compact.py tests/test_eod_sync.py tests/test_task_transitions.py tests/test_archive.py tests/test_done_scan_daily_links.py`.
+- Run `pytest -q` before opening the PR if runtime is acceptable.
+- Run `bash scripts/ci/check-public-hygiene.sh`.
+- Run `python3 scripts/tasks.py --help`, `python3 scripts/tasks.py done --help`, `python3 scripts/tasks.py ingest-daily-log --help`, and `python3 scripts/eod_sync.py --help` to verify public language.
+- For manual verification, use fixture task files with duplicate titles, missing IDs, real `task_id::`, legacy `id::`, objectives format, and high-confidence fuzzy EOD matches.
+
+---
+
+## Sources & References
+
+- `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- `lobster-workflows:docs/brainstorms/2026-05-20-task-tracker-vnext-requirements.md`
+- `lobster-workflows:docs/debug/2026-05-20-task-tracker-ux-failures.md`
+- `lobster-workflows:docs/ideation/2026-05-20-task-tracker-radical-simplification-ideas.md`
+- Oracle architecture review pasted in the planning conversation on 2026-05-20

--- a/references/eod-sync.md
+++ b/references/eod-sync.md
@@ -1,9 +1,8 @@
 # EOD Sync and Weekly Embeds
 
-The legacy EOD workflow can sync completed items from daily notes into Weekly
-TODOs. The canonical identity kernel does not change this workflow yet; future
-completion evidence work should keep EOD extraction evidence-only until a user
-confirms an ID-based completion.
+The EOD workflow reports completed items from daily notes against Weekly TODOs.
+It is evidence-only by default. Legacy Weekly TODO checkbox writes are still
+available behind `--apply`, but they do not complete canonical tasks.
 
 ## Environment
 
@@ -17,6 +16,7 @@ export TASK_TRACKER_DAILY_NOTES_DIR="$HOME/path/to/Daily"
 ```bash
 python3 scripts/eod_sync.py --dry-run
 python3 scripts/eod_sync.py
+python3 scripts/eod_sync.py --apply
 python3 scripts/eod_sync.py --date 2026-02-18
 python3 scripts/eod_sync.py --verbose
 ```
@@ -25,11 +25,13 @@ Behavior:
 
 - Reads `## ✅ Done` from the selected daily note
 - Fuzzy-matches against open tasks in weekly TODOs
-- Marks matched items complete as `- [x] ... ✅ YYYY-MM-DD`
+- Reports evidence links without writing by default
+- With `--apply`, marks matched Weekly TODO items as `- [x] ... ✅ YYYY-MM-DD`
+- Never updates canonical task state; use `tasks.py done <task_id>` for that
 
 Match thresholds:
 
-- `>= 80%`: auto-sync
+- `>= 80%`: evidence-link
 - `60-79%`: uncertain, manual review
 - `< 60%`: skipped
 

--- a/references/task-primitives-schema-v1.md
+++ b/references/task-primitives-schema-v1.md
@@ -67,8 +67,8 @@ Pipeline order is deterministic:
 3. fuzzy match with threshold bands
 
 Threshold decision bands:
-- `score >= auto_threshold` -> `auto-link`
-- `review_threshold <= score < auto_threshold` -> `needs-review`
+- `score >= evidence_link threshold` -> `evidence-link`
+- `review_threshold <= score < evidence_link threshold` -> `needs-review`
 - `score < review_threshold` -> `no-match`
 
 ```json
@@ -80,13 +80,13 @@ Threshold decision bands:
     "path": "/tmp/done-log.md"
   },
   "thresholds": {
-    "auto_link": 0.9,
+    "evidence_link": 0.9,
     "needs_review": 0.7
   },
   "totals": {
     "input_lines": 3,
     "parsed_done_lines": 2,
-    "auto_linked": 1,
+    "evidence_linked": 1,
     "needs_review": 1,
     "no_match": 0
   },
@@ -104,12 +104,15 @@ Threshold decision bands:
         "priority": null,
         "due": null,
         "owner": null,
-        "goal": null
+        "goal": null,
+        "fallback_id": "fallback-abc123",
+        "missing_task_id": false,
+        "fallback_only": false
       },
       "match_metadata": {
         "matched_task_id": "A-1",
         "score": 1.0,
-        "decision": "auto-link",
+        "decision": "evidence-link",
         "match_type": "exact-id-or-link|normalized-title|fuzzy"
       }
     }

--- a/scripts/archive.py
+++ b/scripts/archive.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from utils import parse_tasks
+from task_lines import remove_task_line
 
 
 DEPARTMENT_DISPLAY = {"HR": "HR/People"}
@@ -20,6 +21,7 @@ class ArchiveRecord:
     title: str
     completed_date: str | None
     raw_line: str
+    line_number: int | None
 
 
 def atomic_write(path: Path, content: str) -> None:
@@ -34,21 +36,6 @@ def atomic_write(path: Path, content: str) -> None:
     finally:
         if os.path.exists(tmp_name):
             os.unlink(tmp_name)
-
-
-def _remove_task_line(content: str, raw_line: str) -> str:
-    lines = content.splitlines(keepends=True)
-    result = []
-    i = 0
-    while i < len(lines):
-        if lines[i].rstrip() == raw_line.rstrip():
-            i += 1
-            while i < len(lines) and lines[i].startswith(('  ', '\t')):
-                i += 1
-        else:
-            result.append(lines[i])
-            i += 1
-    return ''.join(result)
 
 
 def get_archive_dir(tasks_file: Path) -> Path:
@@ -91,7 +78,13 @@ def archive_week(tasks_file: Path, personal: bool) -> dict:
             title = task.get('title', raw_line)
             completed_date = task.get('completed_date')
             dept = objective_depts.get(parent, 'Uncategorized')
-            record = ArchiveRecord(department=dept, title=title, completed_date=completed_date, raw_line=raw_line)
+            record = ArchiveRecord(
+                department=dept,
+                title=title,
+                completed_date=completed_date,
+                raw_line=raw_line,
+                line_number=task.get('line_number'),
+            )
             completed_by_dept[dept].append(record)
     
     if not completed_by_dept:
@@ -122,11 +115,16 @@ def archive_week(tasks_file: Path, personal: bool) -> dict:
     
     updated_content = tasks_file.read_text()
     removed = 0
-    for dept_records in completed_by_dept.values():
-        for record in dept_records:
-            if record.raw_line and record.raw_line in updated_content:
-                updated_content = _remove_task_line(updated_content, record.raw_line)
-                removed += 1
+    records_to_remove = [
+        record
+        for dept_records in completed_by_dept.values()
+        for record in dept_records
+    ]
+    for record in sorted(records_to_remove, key=lambda r: r.line_number or 0, reverse=True):
+        updated = remove_task_line(updated_content, record.raw_line, record.line_number)
+        if updated is not None:
+            updated_content = updated
+            removed += 1
     
     if removed > 0:
         atomic_write(tasks_file, updated_content)

--- a/scripts/eod_sync.py
+++ b/scripts/eod_sync.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """
-eod_sync.py — Auto-sync EOD completions from daily notes to Weekly TODOs.
+eod_sync.py — Report EOD completion evidence from daily notes to Weekly TODOs.
 
 For each completed item in the daily note's ✅ Done section, fuzzy-match
-against unchecked tasks in Weekly TODOs and mark them complete.
+against unchecked tasks in Weekly TODOs and report likely evidence links.
+Writes require explicit --apply and remain a legacy weekly TODO helper; they
+do not update canonical task state.
 
 Thresholds:
-  ≥ 80%  → auto-sync (mark done)
+  ≥ 80%  → evidence-link
   60-79% → log as uncertain (manual review needed)
   < 60%  → skip
 
@@ -15,9 +17,9 @@ Configuration via environment variables:
   TASK_TRACKER_DAILY_NOTES_DIR  Directory containing YYYY-MM-DD.md files
 
 Usage:
-  python3 eod_sync.py                   # sync today
-  python3 eod_sync.py --dry-run         # preview without writing
-  python3 eod_sync.py --date 2026-02-18 # sync a specific day
+  python3 eod_sync.py                   # report today, no writes
+  python3 eod_sync.py --apply           # legacy write to Weekly TODOs
+  python3 eod_sync.py --date 2026-02-18 # report a specific day
   python3 eod_sync.py --verbose         # show all match scores
 """
 
@@ -53,7 +55,7 @@ DAILY_NOTES_DIR = Path(
 # Threshold constants
 # ---------------------------------------------------------------------------
 
-AUTO_SYNC_THRESHOLD = 0.80   # ≥ 80% → auto-sync
+AUTO_SYNC_THRESHOLD = 0.80   # >= 80% -> evidence-link
 UNCERTAIN_THRESHOLD = 0.60   # 60-79% → log uncertain
 
 # ---------------------------------------------------------------------------
@@ -194,7 +196,7 @@ def build_sync_plan(
     For each done_item, find the best-matching open task.
 
     Returns list of result dicts:
-      status: 'sync' | 'uncertain' | 'skip'
+    status: 'evidence' | 'uncertain' | 'skip'
       done_item: original done item text
       match: matched task dict or None
       score: float 0-1
@@ -223,7 +225,7 @@ def build_sync_plan(
             matched_task_indices.add(best_idx)
             results.append(
                 {
-                    "status": "sync",
+                    "status": "evidence",
                     "done_item": done_item,
                     "match": best_task,
                     "score": best_score,
@@ -263,7 +265,7 @@ def apply_sync_plan(
     updated = list(weekly_lines)
 
     for result in plan:
-        if result["status"] != "sync":
+        if result["status"] not in {"sync", "evidence"}:
             continue
         task = result["match"]
         idx = task["line_idx"]
@@ -292,12 +294,12 @@ def apply_sync_plan(
 
 def print_report(plan: list[SyncResult], dry_run: bool, verbose: bool = False) -> None:
     """Print a human-readable sync report."""
-    synced = [r for r in plan if r["status"] == "sync"]
+    synced = [r for r in plan if r["status"] in {"sync", "evidence"}]
     uncertain = [r for r in plan if r["status"] == "uncertain"]
     skipped = [r for r in plan if r["status"] == "skip"]
 
     mode = "DRY RUN — " if dry_run else ""
-    print(f"\n{mode}EOD Sync Report")
+    print(f"\n{mode}EOD Evidence Report")
     print("=" * 50)
 
     if verbose:
@@ -305,15 +307,15 @@ def print_report(plan: list[SyncResult], dry_run: bool, verbose: bool = False) -
         print("\n📊 All match attempts:")
         for r in plan:
             pct = int(r["score"] * 100)
-            status_icon = {"sync": "✅", "uncertain": "⚠️", "skip": "⏭️"}[r["status"]]
+            status_icon = {"sync": "✅", "evidence": "🔎", "uncertain": "⚠️", "skip": "⏭️"}[r["status"]]
             weekly_title = r["match"]["body"] if r["match"] else "(no match)"
             print(f"  {status_icon} [{pct}%] {normalize(r['done_item'])}")
             if r["match"]:
                 print(f"         → {normalize(weekly_title)}")
     else:
-        # Default: show only synced, uncertain, skipped summaries
+        # Default: show only evidence, uncertain, skipped summaries
         if synced:
-            print(f"\n✅ Auto-synced ({len(synced)}):")
+            print(f"\n🔎 Evidence links ({len(synced)}):")
             for r in synced:
                 pct = int(r["score"] * 100)
                 weekly_title = r["match"]["body"] if r["match"] else "?"
@@ -336,7 +338,7 @@ def print_report(plan: list[SyncResult], dry_run: bool, verbose: bool = False) -
                 print(f"  {label}{normalize(r['done_item'])!r}")
 
     print()
-    action = "Would sync" if dry_run else "Synced"
+    action = "Would legacy-apply" if dry_run else "Legacy-applied"
     print(
         f"Summary: {action} {len(synced)}, uncertain {len(uncertain)}, "
         f"skipped {len(skipped)}"
@@ -350,19 +352,24 @@ def print_report(plan: list[SyncResult], dry_run: bool, verbose: bool = False) -
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Sync EOD completions from daily notes to Weekly TODOs.",
+        description="Report EOD completion evidence from daily notes to Weekly TODOs.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
     parser.add_argument(
         "--date",
         default=None,
-        help="Date to sync (YYYY-MM-DD). Defaults to today.",
+        help="Date to report (YYYY-MM-DD). Defaults to today.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview what would change without writing files.",
+        help="Preview what would change without writing files. This is now the default.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Legacy weekly TODO write mode. Does not update canonical task state.",
     )
     parser.add_argument(
         "--verbose",
@@ -373,7 +380,7 @@ def main() -> None:
         "--threshold",
         type=float,
         default=None,
-        help="Override auto-sync threshold (0-1, default 0.80).",
+        help="Override evidence-link threshold (0-1, default 0.80).",
     )
     args = parser.parse_args()
 
@@ -428,10 +435,17 @@ def main() -> None:
     plan = build_sync_plan(done_items, open_tasks, sync_date, verbose=args.verbose)
 
     # Print report
-    print_report(plan, dry_run=args.dry_run, verbose=args.verbose)
+    report_only = args.dry_run or not args.apply
+    print_report(plan, dry_run=report_only, verbose=args.verbose)
 
-    # Apply plan (unless dry run)
-    if not args.dry_run:
+    if not args.apply:
+        print("ℹ️  Report-only mode: no files written. Use --apply for legacy Weekly TODO writes.")
+        return
+
+    print("⚠️  Legacy apply mode: this writes Weekly TODO checkboxes only; canonical tasks are unchanged.")
+
+    # Apply plan only when explicitly requested.
+    if args.apply:
         new_lines = apply_sync_plan(weekly_lines, plan, sync_date)
         new_content = "".join(new_lines)
 
@@ -439,7 +453,7 @@ def main() -> None:
             print("ℹ️  No changes to write.")
         else:
             WEEKLY_TODOS_PATH.write_text(new_content, encoding="utf-8")
-            synced_count = sum(1 for r in plan if r["status"] == "sync")
+            synced_count = sum(1 for r in plan if r["status"] in {"sync", "evidence"})
             print(f"✅ Wrote {WEEKLY_TODOS_PATH.name} ({synced_count} task(s) marked done)")
 
 

--- a/scripts/eod_sync.py
+++ b/scripts/eod_sync.py
@@ -441,6 +441,9 @@ def main() -> None:
     if not args.apply:
         print("ℹ️  Report-only mode: no files written. Use --apply for legacy Weekly TODO writes.")
         return
+    if args.dry_run:
+        print("ℹ️  Dry-run mode: no files written. Remove --dry-run to use legacy --apply writes.")
+        return
 
     print("⚠️  Legacy apply mode: this writes Weekly TODO checkboxes only; canonical tasks are unchanged.")
 

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -20,6 +20,7 @@ from standup_common import (
     get_calendar_events,
     resolve_standup_date,
 )
+from task_records import fallback_id_for
 from utils import (
     load_tasks,
     get_missed_tasks_bucketed,
@@ -43,6 +44,23 @@ def group_by_area(tasks):
             areas[area] = []
         areas[area].append(t)
     return areas
+
+
+def _identity_fields(task: dict) -> dict:
+    raw_line = str(task.get("raw_line") or "")
+    line_number = task.get("line_number")
+    try:
+        line_number_int = int(line_number) if line_number else None
+    except (TypeError, ValueError):
+        line_number_int = None
+    task_id = task.get("task_id") or task.get("legacy_id")
+    fallback_id = fallback_id_for(raw_line, line_number_int) if raw_line else None
+    return {
+        "task_id": task_id,
+        "fallback_id": fallback_id,
+        "missing_task_id": task.get("task_id") is None,
+        "fallback_only": task_id is None,
+    }
 
 
 def format_split_standup(output: dict, date_display: str) -> list:
@@ -201,13 +219,23 @@ def build_compact_standup_sections(output: dict) -> dict:
     """Compact standup payload schema v1 for automation clients."""
     done = [t.get('title', '') for t in (output.get('completed') or [])[:12]]
     calendar_dos = [
-        {"quick_id": f"c{idx}", "title": t.get('title', ''), "status": "scheduled"}
+        {
+            "quick_id": f"c{idx}",
+            "title": t.get('title', ''),
+            "status": "scheduled",
+            **_identity_fields(t),
+        }
         for idx, t in enumerate(output.get('due_today') or [], start=1)
     ]
 
     completed = output.get('completed') or []
     calendar_dones = [
-        {"quick_id": f"cd{idx}", "title": t.get('title', ''), "status": "done"}
+        {
+            "quick_id": f"cd{idx}",
+            "title": t.get('title', ''),
+            "status": "done",
+            **_identity_fields(t),
+        }
         for idx, t in enumerate(
             [
                 t for t in completed
@@ -224,7 +252,14 @@ def build_compact_standup_sections(output: dict) -> dict:
         + [("q3", t) for t in (output.get('q3') or [])]
     )
     for idx, (section, t) in enumerate(stack[:20], start=1):
-        dos.append({"quick_id": f"d{idx}", "title": t.get('title', ''), "section": section})
+        dos.append(
+            {
+                "quick_id": f"d{idx}",
+                "title": t.get('title', ''),
+                "section": section,
+                **_identity_fields(t),
+            }
+        )
 
     return {
         "schema_version": "1",

--- a/scripts/standup_common.py
+++ b/scripts/standup_common.py
@@ -126,9 +126,11 @@ def format_missed_tasks_block(missed_buckets: dict | None) -> str:
         missed_lines.append("\n  **Yesterday:**")
         for task in missed_buckets["yesterday"]:
             title = task.get("title", "")
-            missed_lines.append(
-                f'    • {title} — say "done {title}" to mark complete'
-            )
+            task_id = task.get("task_id") or task.get("legacy_id")
+            if task_id:
+                missed_lines.append(f'    • {title} — say "done {task_id}" to mark complete')
+            else:
+                missed_lines.append(f"    • {title} — missing task_id::; repair identity before completion")
 
     if missed_buckets.get("last7"):
         missed_lines.append("\n  **Last 7 Days:**")

--- a/scripts/task_identity.py
+++ b/scripts/task_identity.py
@@ -3,128 +3,19 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import re
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Iterable
 
-from utils import get_tasks_file, parse_tasks
-
-TASK_ID_RE = re.compile(r"\btask_id::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])")
-LEGACY_ID_RE = re.compile(r"\bid::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])")
-
-
-@dataclass(frozen=True)
-class IdentityRecord:
-    task_id: str | None
-    legacy_id: str | None
-    title: str
-    done: bool
-    section: str | None
-    area: str | None
-    line_number: int | None
-    raw_line: str
-    fallback_id: str
-
-    @property
-    def canonical_id(self) -> str | None:
-        return self.task_id or self.legacy_id
-
-    @property
-    def identity_source(self) -> str:
-        if self.task_id:
-            return "task_id"
-        if self.legacy_id:
-            return "legacy_id"
-        return "fallback"
-
-
-def fallback_id_for(raw_line: str, line_number: int | None) -> str:
-    material = f"{line_number or 0}\0{raw_line}".encode("utf-8")
-    return f"fallback-{hashlib.sha1(material).hexdigest()[:12]}"
-
-
-def opaque_task_id(raw_line: str, line_number: int | None) -> str:
-    material = f"task-v1\0{line_number or 0}\0{raw_line}".encode("utf-8")
-    return f"tsk_{hashlib.sha256(material).hexdigest()[:16]}"
-
-
-def _parking_lot_line_numbers(content: str) -> set[int]:
-    parking_lines: set[int] = set()
-    in_parking_lot = False
-    for idx, line in enumerate(content.splitlines(), start=1):
-        if re.match(r"##\s+(?:🅿️\s*)?Parking Lot\b", line, re.IGNORECASE):
-            in_parking_lot = True
-            continue
-        if in_parking_lot and re.match(r"##\s+", line):
-            in_parking_lot = False
-        if in_parking_lot:
-            parking_lines.add(idx)
-    return parking_lines
-
-
-def task_records(content: str, personal: bool = False, fmt: str = "obsidian") -> list[IdentityRecord]:
-    parsed = parse_tasks(content, personal=personal, format=fmt)
-    parking_lot_lines = _parking_lot_line_numbers(content)
-    records: list[IdentityRecord] = []
-    for task in parsed.get("all", []):
-        raw_line = str(task.get("raw_line") or "")
-        line_number = task.get("line_number")
-        line_number_int = int(line_number) if line_number else None
-        section = task.get("section")
-        if line_number_int in parking_lot_lines:
-            section = "parking_lot"
-        records.append(
-            IdentityRecord(
-                task_id=task.get("task_id"),
-                legacy_id=task.get("legacy_id"),
-                title=str(task.get("title") or ""),
-                done=bool(task.get("done")),
-                section=section,
-                area=task.get("area") or task.get("department"),
-                line_number=line_number_int,
-                raw_line=raw_line,
-                fallback_id=fallback_id_for(raw_line, line_number_int),
-            )
-        )
-    return records
-
-
-def load_records(personal: bool = False) -> tuple[Path, str, list[IdentityRecord]]:
-    tasks_file, fmt = get_tasks_file(personal)
-    if not tasks_file.exists():
-        raise FileNotFoundError(f"Tasks file not found: {tasks_file}")
-    content = tasks_file.read_text(encoding="utf-8")
-    return tasks_file, content, task_records(content, personal=personal, fmt=fmt)
-
-
-def active_records(records: Iterable[IdentityRecord]) -> list[IdentityRecord]:
-    inactive_sections = {"backlog", "parking_lot"}
-    return [record for record in records if not record.done and record.section not in inactive_sections]
-
-
-def export_active(records: Iterable[IdentityRecord]) -> list[dict]:
-    exported = []
-    for record in active_records(records):
-        exported.append(
-            {
-                "task_id": record.canonical_id,
-                "identity_source": record.identity_source,
-                "fallback_id": record.fallback_id,
-                "title": record.title,
-                "state": "active",
-                "section": record.section,
-                "area": record.area,
-                "line_number": record.line_number,
-                "raw_line": record.raw_line,
-                "missing_task_id": record.task_id is None,
-                "fallback_only": record.canonical_id is None,
-                "checked_candidate": record.done,
-            }
-        )
-    return exported
+from task_records import (
+    IdentityRecord,
+    TASK_ID_RE,
+    active_records,
+    export_active,
+    load_records,
+    opaque_task_id,
+    task_records,
+)
+from utils import get_tasks_file
 
 
 def audit_identity(records: Iterable[IdentityRecord]) -> dict:

--- a/scripts/task_lines.py
+++ b/scripts/task_lines.py
@@ -15,12 +15,16 @@ def line_index(lines: list[str], raw_line: str, line_number: int | None) -> int 
     return index
 
 
+def leading_indent_width(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
 def remove_task_line(content: str, raw_line: str, line_number: int | None) -> str | None:
     lines = content.split("\n")
     target_index = line_index(lines, raw_line, line_number)
     if target_index is None:
         return None
-    target_indent = len(raw_line) - len(raw_line.lstrip(" "))
+    target_indent = leading_indent_width(raw_line)
     remove_until = target_index + 1
     while remove_until < len(lines):
         line = lines[remove_until]
@@ -29,12 +33,12 @@ def remove_task_line(content: str, raw_line: str, line_number: int | None) -> st
             while lookahead < len(lines) and not lines[lookahead].strip():
                 lookahead += 1
             if lookahead < len(lines):
-                next_indent = len(lines[lookahead]) - len(lines[lookahead].lstrip(" "))
+                next_indent = leading_indent_width(lines[lookahead])
                 if next_indent > target_indent:
                     remove_until += 1
                     continue
             break
-        indent = len(line) - len(line.lstrip(" "))
+        indent = leading_indent_width(line)
         if indent > target_indent:
             remove_until += 1
             continue

--- a/scripts/task_lines.py
+++ b/scripts/task_lines.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Line-number verified task board text edits."""
+
+from __future__ import annotations
+
+
+def line_index(lines: list[str], raw_line: str, line_number: int | None) -> int | None:
+    if line_number is None:
+        return None
+    index = line_number - 1
+    if index < 0 or index >= len(lines):
+        return None
+    if lines[index] != raw_line:
+        return None
+    return index
+
+
+def remove_task_line(content: str, raw_line: str, line_number: int | None) -> str | None:
+    lines = content.split("\n")
+    target_index = line_index(lines, raw_line, line_number)
+    if target_index is None:
+        return None
+    target_indent = len(raw_line) - len(raw_line.lstrip(" "))
+    remove_until = target_index + 1
+    while remove_until < len(lines):
+        line = lines[remove_until]
+        if not line.strip():
+            lookahead = remove_until + 1
+            while lookahead < len(lines) and not lines[lookahead].strip():
+                lookahead += 1
+            if lookahead < len(lines):
+                next_indent = len(lines[lookahead]) - len(lines[lookahead].lstrip(" "))
+                if next_indent > target_indent:
+                    remove_until += 1
+                    continue
+            break
+        indent = len(line) - len(line.lstrip(" "))
+        if indent > target_indent:
+            remove_until += 1
+            continue
+        break
+    return "\n".join(lines[:target_index] + lines[remove_until:])
+
+
+def replace_task_line(
+    content: str,
+    raw_line: str,
+    replacement: str,
+    line_number: int | None,
+) -> str | None:
+    lines = content.split("\n")
+    target_index = line_index(lines, raw_line, line_number)
+    if target_index is None:
+        return None
+    lines[target_index] = replacement
+    return "\n".join(lines)

--- a/scripts/task_records.py
+++ b/scripts/task_records.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Shared canonical task record helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from utils import get_tasks_file, parse_tasks
+
+TASK_ID_RE = re.compile(r"\btask_id::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])")
+LEGACY_ID_RE = re.compile(r"\bid::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])")
+
+
+@dataclass(frozen=True)
+class TaskRecord:
+    task_id: str | None
+    legacy_id: str | None
+    title: str
+    done: bool
+    section: str | None
+    area: str | None
+    line_number: int | None
+    raw_line: str
+    fallback_id: str
+    department: str | None = None
+    priority: str | None = None
+    due: str | None = None
+    owner: str | None = None
+    goal: str | None = None
+    recur: str | None = None
+    parent_objective: str | None = None
+    is_objective: bool = False
+
+    @property
+    def canonical_id(self) -> str | None:
+        return self.task_id or self.legacy_id
+
+    @property
+    def identity_source(self) -> str:
+        if self.task_id:
+            return "task_id"
+        if self.legacy_id:
+            return "legacy_id"
+        return "fallback"
+
+    @property
+    def missing_task_id(self) -> bool:
+        return self.task_id is None
+
+    @property
+    def fallback_only(self) -> bool:
+        return self.canonical_id is None
+
+
+IdentityRecord = TaskRecord
+
+
+def fallback_id_for(raw_line: str, line_number: int | None) -> str:
+    material = f"{line_number or 0}\0{raw_line}".encode("utf-8")
+    return f"fallback-{hashlib.sha1(material).hexdigest()[:12]}"
+
+
+def opaque_task_id(raw_line: str, line_number: int | None) -> str:
+    material = f"task-v1\0{line_number or 0}\0{raw_line}".encode("utf-8")
+    return f"tsk_{hashlib.sha256(material).hexdigest()[:16]}"
+
+
+def parking_lot_line_numbers(content: str) -> set[int]:
+    parking_lines: set[int] = set()
+    in_parking_lot = False
+    for idx, line in enumerate(content.splitlines(), start=1):
+        if re.match(r"##\s+(?:🅿️\s*)?Parking Lot\b", line, re.IGNORECASE):
+            in_parking_lot = True
+            continue
+        if in_parking_lot and re.match(r"##\s+", line):
+            in_parking_lot = False
+        if in_parking_lot:
+            parking_lines.add(idx)
+    return parking_lines
+
+
+def task_records(content: str, personal: bool = False, fmt: str = "obsidian") -> list[TaskRecord]:
+    parsed = parse_tasks(content, personal=personal, format=fmt)
+    parking_lot_lines = parking_lot_line_numbers(content)
+    records: list[TaskRecord] = []
+    for task in parsed.get("all", []):
+        raw_line = str(task.get("raw_line") or "")
+        line_number = task.get("line_number")
+        line_number_int = int(line_number) if line_number else None
+        section = task.get("section")
+        if line_number_int in parking_lot_lines:
+            section = "parking_lot"
+        area = task.get("area") or task.get("department")
+        records.append(
+            TaskRecord(
+                task_id=task.get("task_id"),
+                legacy_id=task.get("legacy_id"),
+                title=str(task.get("title") or ""),
+                done=bool(task.get("done")),
+                section=section,
+                area=area,
+                line_number=line_number_int,
+                raw_line=raw_line,
+                fallback_id=fallback_id_for(raw_line, line_number_int),
+                department=task.get("department"),
+                priority=task.get("priority"),
+                due=task.get("due"),
+                owner=task.get("owner"),
+                goal=task.get("goal"),
+                recur=task.get("recur"),
+                parent_objective=task.get("parent_objective"),
+                is_objective=bool(task.get("is_objective")),
+            )
+        )
+    return records
+
+
+def load_records(personal: bool = False) -> tuple[Path, str, list[TaskRecord]]:
+    tasks_file, fmt = get_tasks_file(personal)
+    if not tasks_file.exists():
+        raise FileNotFoundError(f"Tasks file not found: {tasks_file}")
+    content = tasks_file.read_text(encoding="utf-8")
+    return tasks_file, content, task_records(content, personal=personal, fmt=fmt)
+
+
+def active_records(records: Iterable[TaskRecord]) -> list[TaskRecord]:
+    inactive_sections = {"backlog", "parking_lot"}
+    return [record for record in records if not record.done and record.section not in inactive_sections]
+
+
+def record_to_task_dict(record: TaskRecord) -> dict:
+    return {
+        "task_id": record.canonical_id,
+        "identity_source": record.identity_source,
+        "fallback_id": record.fallback_id,
+        "missing_task_id": record.missing_task_id,
+        "fallback_only": record.fallback_only,
+        "title": record.title,
+        "done": record.done,
+        "section": record.section,
+        "area": record.area or record.department or "Uncategorized",
+        "department": record.department,
+        "priority": record.priority,
+        "due": record.due,
+        "owner": record.owner,
+        "goal": record.goal,
+        "recur": record.recur,
+        "parent_objective": record.parent_objective,
+        "is_objective": record.is_objective,
+        "line_number": record.line_number,
+        "raw_line": record.raw_line,
+    }
+
+
+def export_active(records: Iterable[TaskRecord]) -> list[dict]:
+    exported = []
+    for record in active_records(records):
+        row = record_to_task_dict(record)
+        row["state"] = "active"
+        row["checked_candidate"] = record.done
+        exported.append(row)
+    return exported

--- a/scripts/task_transitions.py
+++ b/scripts/task_transitions.py
@@ -10,60 +10,14 @@ from datetime import datetime
 from pathlib import Path
 
 from log_done import log_task_completed
-from task_identity import active_records, load_records
+from task_lines import remove_task_line, replace_task_line
+from task_records import active_records, load_records
 from task_ledger import append_event, ledger_path, new_event
 from utils import next_recurrence_date
 
 INLINE_FIELD_RE = re.compile(r"\s+[A-Za-z_][A-Za-z0-9_-]*::")
 RECURRENCE_RE = re.compile(r"\brecur::\s*(?!(?:\s|[A-Za-z_][A-Za-z0-9_-]*::))([^\n]+?)(?=\s+[A-Za-z_][A-Za-z0-9_-]*::|\s*[🗓️📅]|$)")
 DUE_RE = re.compile(r"(?:🗓️\s*|📅\s*)(\d{4}-\d{2}-\d{2})")
-
-
-def _line_index(lines: list[str], raw_line: str, line_number: int | None) -> int | None:
-    if line_number is None:
-        return None
-    index = line_number - 1
-    if index < 0 or index >= len(lines):
-        return None
-    if lines[index] != raw_line:
-        return None
-    return index
-
-
-def _remove_task_line(content: str, raw_line: str, line_number: int | None) -> str | None:
-    lines = content.split("\n")
-    target_index = _line_index(lines, raw_line, line_number)
-    if target_index is None:
-        return None
-    target_indent = len(raw_line) - len(raw_line.lstrip(" "))
-    remove_until = target_index + 1
-    while remove_until < len(lines):
-        line = lines[remove_until]
-        if not line.strip():
-            lookahead = remove_until + 1
-            while lookahead < len(lines) and not lines[lookahead].strip():
-                lookahead += 1
-            if lookahead < len(lines):
-                next_indent = len(lines[lookahead]) - len(lines[lookahead].lstrip(" "))
-                if next_indent > target_indent:
-                    remove_until += 1
-                    continue
-            break
-        indent = len(line) - len(line.lstrip(" "))
-        if indent > target_indent:
-            remove_until += 1
-            continue
-        break
-    return "\n".join(lines[:target_index] + lines[remove_until:])
-
-
-def _replace_task_line(content: str, raw_line: str, replacement: str, line_number: int | None) -> str | None:
-    lines = content.split("\n")
-    target_index = _line_index(lines, raw_line, line_number)
-    if target_index is None:
-        return None
-    lines[target_index] = replacement
-    return "\n".join(lines)
 
 
 def _set_due_date(raw_line: str, due_date: str) -> str:
@@ -189,7 +143,7 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
             from_date = due_value or datetime.now().date().isoformat()
             next_due = next_recurrence_date(recur_value, from_date)
             next_line = _set_due_date(record.raw_line, next_due)
-            new_content = _replace_task_line(content, record.raw_line, next_line, record.line_number)
+            new_content = replace_task_line(content, record.raw_line, next_line, record.line_number)
         except ValueError as exc:
             return {
                 "ok": False,
@@ -199,7 +153,7 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
                 },
             }
     else:
-        new_content = _remove_task_line(content, record.raw_line, record.line_number)
+        new_content = remove_task_line(content, record.raw_line, record.line_number)
     if new_content is None:
         return {
             "ok": False,

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -24,12 +24,17 @@ from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).parent))
 from daily_notes import extract_completed_tasks
-from log_done import log_task_completed
 from standup_common import get_calendar_events, flatten_calendar_events
 import delegation
 from task_identity import audit_payload, print_json as print_identity_json
+from task_lines import remove_task_line
 from task_repair import repair_missing_ids
 from task_transitions import block_unsafe_query, complete_by_id, print_result
+from task_records import (
+    active_records,
+    record_to_task_dict,
+    task_records as build_task_records,
+)
 from utils import (
     detect_format,
     get_tasks_file,
@@ -37,14 +42,13 @@ from utils import (
     parse_tasks,
     load_tasks,
     check_due_date,
-    next_recurrence_date,
     get_current_quarter,
     ARCHIVE_DIR,
     get_objective_progress,
 )
 
 TASK_PRIMITIVES_SCHEMA_VERSION = "v1"
-FUZZY_AUTO_LINK_THRESHOLD = 0.90
+FUZZY_EVIDENCE_LINK_THRESHOLD = 0.90
 FUZZY_REVIEW_THRESHOLD = 0.70
 
 
@@ -192,42 +196,6 @@ def add_task(args):
         print(f"⚠️ Could not find section matching '{priority_pattern}'. Add manually.")
 
 
-def _remove_task_line(content: str, raw_line: str) -> str:
-    """Remove a task line and its child/continuation lines."""
-    lines = content.split('\n')
-    try:
-        target_index = lines.index(raw_line)
-    except ValueError:
-        return content
-
-    target_indent = len(raw_line) - len(raw_line.lstrip(' '))
-    remove_until = target_index + 1
-
-    while remove_until < len(lines):
-        line = lines[remove_until]
-
-        if line.strip() == '':
-            lookahead = remove_until + 1
-            while lookahead < len(lines) and lines[lookahead].strip() == '':
-                lookahead += 1
-
-            if lookahead < len(lines):
-                next_line = lines[lookahead]
-                next_indent = len(next_line) - len(next_line.lstrip(' '))
-                if next_indent > target_indent:
-                    remove_until += 1
-                    continue
-            break
-
-        indent = len(line) - len(line.lstrip(' '))
-        if indent > target_indent:
-            remove_until += 1
-            continue
-        break
-
-    return '\n'.join(lines[:target_index] + lines[remove_until:])
-
-
 def done_task(args):
     """Complete a task by canonical ID only."""
     query = args.query.strip()
@@ -351,10 +319,12 @@ def archive_done(args):
     removed = 0
     if stale_board and tasks_file.exists():
         board_content = tasks_file.read_text()
-        for task in stale_board:
+        for task in sorted(stale_board, key=lambda t: t.get('line_number') or 0, reverse=True):
             raw_line = task.get('raw_line', '')
-            if raw_line and raw_line in board_content:
-                board_content = _remove_task_line(board_content, raw_line)
+            line_number = task.get('line_number')
+            updated = remove_task_line(board_content, raw_line, line_number)
+            if updated is not None:
+                board_content = updated
                 removed += 1
         tasks_file.write_text(board_content)
 
@@ -449,20 +419,6 @@ def cmd_parking_lot(args):
             str(tasks_file.parent / 'Done Archive')
         ))
         print(drop_item(tasks_file, args.id, archive_dir=archive_dir))
-
-
-def _find_open_task(personal: bool, query: str) -> tuple[Path, dict | None, str]:
-    tasks_file, fmt = get_tasks_file(personal)
-    if not tasks_file.exists():
-        return tasks_file, None, f"❌ Tasks file not found: {tasks_file}"
-    content = tasks_file.read_text()
-    tasks_data = parse_tasks(content, personal, fmt)
-    matches = [t for t in tasks_data.get('all', []) if not t.get('done') and query.lower() in t.get('title', '').lower()]
-    if not matches:
-        return tasks_file, None, f"❌ No open task matches: {query}"
-    if len(matches) > 1:
-        return tasks_file, None, f"❌ Multiple matches for '{query}'. Be more specific."
-    return tasks_file, matches[0], ""
 
 
 def cmd_identity_audit(args):
@@ -674,6 +630,20 @@ def _safe_load_tasks(personal: bool = False) -> dict:
         return empty
 
 
+def _safe_load_task_records(personal: bool = False) -> list:
+    tasks_file, fmt = get_tasks_file(personal)
+    if not tasks_file.exists():
+        return []
+    try:
+        content = tasks_file.read_text()
+    except OSError:
+        return []
+    try:
+        return build_task_records(content, personal=personal, fmt=fmt)
+    except Exception:
+        return []
+
+
 def _normalize_title(title: str) -> str:
     lowered = (title or "").strip().casefold()
     lowered = re.sub(r"\[x\]|\[ \]|✅|☑️", " ", lowered)
@@ -681,13 +651,6 @@ def _normalize_title(title: str) -> str:
     lowered = re.sub(r"[^\w\s/-]", " ", lowered)
     lowered = re.sub(r"\s+", " ", lowered)
     return lowered.strip()
-
-
-def _slugify(value: str) -> str:
-    normalized = _normalize_title(value)
-    slug = re.sub(r"[^a-z0-9]+", "-", normalized)
-    slug = re.sub(r"-{2,}", "-", slug).strip("-")
-    return slug or "task"
 
 
 def _extract_inline_identifiers(text: str) -> dict[str, set[str]]:
@@ -717,49 +680,21 @@ def _extract_inline_identifiers(text: str) -> dict[str, set[str]]:
     return {"exact": exact_identifiers, "fallback": fallback_identifiers}
 
 
-def _task_identifier_bundle(task: dict, fallback_id: str) -> dict:
-    raw_line = str(task.get("raw_line") or "")
-    title = str(task.get("title") or "")
-    explicit_id = None
-    parsed_task_id = str(task.get("task_id") or "").strip()
-    parsed_legacy_id = str(task.get("legacy_id") or "").strip()
-    legacy_id_match = re.search(r"\bid::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])", raw_line, flags=re.IGNORECASE)
-    task_alias_match = re.search(r"\btask::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])", raw_line, flags=re.IGNORECASE)
-    if parsed_task_id:
-        explicit_id = parsed_task_id
-    elif parsed_legacy_id:
-        explicit_id = parsed_legacy_id
-    elif legacy_id_match:
-        explicit_id = legacy_id_match.group(1)
-    elif task_alias_match:
-        explicit_id = task_alias_match.group(1)
-
-    raw_identifiers = _extract_inline_identifiers(raw_line)
-    title_identifiers = _extract_inline_identifiers(title)
+def _record_identifier_bundle(record) -> dict:
+    raw_identifiers = _extract_inline_identifiers(record.raw_line)
+    title_identifiers = _extract_inline_identifiers(record.title)
     exact_identifiers = raw_identifiers["exact"] | title_identifiers["exact"]
     fallback_identifiers = raw_identifiers["fallback"] | title_identifiers["fallback"]
-    if explicit_id:
-        exact_identifiers.add(explicit_id.casefold())
-
+    if record.canonical_id:
+        exact_identifiers.add(record.canonical_id.casefold())
     return {
-        "task_id": explicit_id or fallback_id,
         "exact_identifiers": exact_identifiers,
         "fallback_identifiers": fallback_identifiers,
     }
 
 
-def _canonical_task(task: dict, task_id: str) -> dict:
-    return {
-        "task_id": task_id,
-        "title": task.get("title", ""),
-        "done": bool(task.get("done")),
-        "section": task.get("section"),
-        "area": task.get("area") or task.get("department") or "Uncategorized",
-        "priority": task.get("priority"),
-        "due": task.get("due"),
-        "owner": task.get("owner"),
-        "goal": task.get("goal"),
-    }
+def _canonical_record(record) -> dict:
+    return record_to_task_dict(record)
 
 
 def _group_tasks_by_area(tasks: list[dict]) -> dict[str, list[dict]]:
@@ -859,15 +794,14 @@ def _fuzzy_score(left: str, right: str) -> float:
     return SequenceMatcher(None, left, right).ratio()
 
 
-def _build_task_catalog(tasks_data: dict) -> list[dict]:
+def _build_task_catalog(records: list) -> list[dict]:
     catalog: list[dict] = []
-    for idx, task in enumerate(tasks_data.get("all", []), start=1):
-        fallback_id = f"{_slugify(task.get('title', 'task'))}-{idx:03d}"
-        bundle = _task_identifier_bundle(task, fallback_id=fallback_id)
-        canonical = _canonical_task(task, bundle["task_id"])
+    for record in records:
+        bundle = _record_identifier_bundle(record)
+        canonical = _canonical_record(record)
         catalog.append(
             {
-                "task": task,
+                "record": record,
                 "canonical": canonical,
                 "normalized_title": _normalize_title(canonical["title"]),
                 "exact_identifiers": bundle["exact_identifiers"],
@@ -877,31 +811,23 @@ def _build_task_catalog(tasks_data: dict) -> list[dict]:
     return catalog
 
 
-def _task_id_lookup(tasks_data: dict) -> dict[int, str]:
-    lookup: dict[int, str] = {}
-    for entry in _build_task_catalog(tasks_data):
-        lookup[id(entry["task"])] = entry["canonical"]["task_id"]
-    return lookup
-
-
-def _canonical_task_with_lookup(task: dict, task_ids: dict[int, str]) -> dict:
-    fallback_id = _slugify(task.get("title", ""))
-    return _canonical_task(task, task_ids.get(id(task), fallback_id))
-
-
 def _ingest_match_line(
     line: dict,
     catalog: list[dict],
     auto_threshold: float,
     review_threshold: float,
 ) -> dict:
+    def _sort_key(candidate: dict) -> str:
+        canonical = candidate["canonical"]
+        return canonical.get("task_id") or canonical.get("fallback_id") or canonical.get("title") or ""
+
     exact_matches = [
         candidate
         for candidate in catalog
         if line["exact_identifiers"] and (line["exact_identifiers"] & candidate["exact_identifiers"])
     ]
     if exact_matches:
-        chosen = sorted(exact_matches, key=lambda c: c["canonical"]["task_id"])[0]
+        chosen = sorted(exact_matches, key=_sort_key)[0]
         return {
             "raw_line": line["raw_line"],
             "parsed_title": line["title"],
@@ -910,7 +836,7 @@ def _ingest_match_line(
             "match_metadata": {
                 "matched_task_id": chosen["canonical"]["task_id"],
                 "score": 1.0,
-                "decision": "auto-link",
+                "decision": "evidence-link",
                 "match_type": "exact-id-or-link",
             },
         }
@@ -921,7 +847,7 @@ def _ingest_match_line(
         if line["fallback_identifiers"] and (line["fallback_identifiers"] & candidate["fallback_identifiers"])
     ]
     if fallback_matches:
-        chosen = sorted(fallback_matches, key=lambda c: c["canonical"]["task_id"])[0]
+        chosen = sorted(fallback_matches, key=_sort_key)[0]
         return {
             "raw_line": line["raw_line"],
             "parsed_title": line["title"],
@@ -939,7 +865,7 @@ def _ingest_match_line(
         candidate for candidate in catalog if candidate["normalized_title"] == line["normalized_title"]
     ]
     if exact_title_matches:
-        chosen = sorted(exact_title_matches, key=lambda c: c["canonical"]["task_id"])[0]
+        chosen = sorted(exact_title_matches, key=_sort_key)[0]
         return {
             "raw_line": line["raw_line"],
             "parsed_title": line["title"],
@@ -948,7 +874,7 @@ def _ingest_match_line(
             "match_metadata": {
                 "matched_task_id": chosen["canonical"]["task_id"],
                 "score": 1.0,
-                "decision": "auto-link",
+                "decision": "evidence-link",
                 "match_type": "normalized-title",
             },
         }
@@ -956,13 +882,13 @@ def _ingest_match_line(
     scored = []
     for candidate in catalog:
         score = _fuzzy_score(line["normalized_title"], candidate["normalized_title"])
-        scored.append((score, candidate["canonical"]["task_id"], candidate))
+        scored.append((score, _sort_key(candidate), candidate))
     scored.sort(key=lambda item: (-item[0], item[1]))
     best_score, _, best = scored[0] if scored else (0.0, "", None)
 
     decision = "no-match"
     if best and best_score >= auto_threshold:
-        decision = "auto-link"
+        decision = "evidence-link"
     elif best and best_score >= review_threshold:
         decision = "needs-review"
 
@@ -982,7 +908,7 @@ def _ingest_match_line(
 
 def cmd_standup_summary(args):
     tasks_data = _safe_load_tasks(args.personal)
-    task_ids = _task_id_lookup(tasks_data)
+    records = _safe_load_task_records(args.personal)
     today = datetime.now().date()
 
     notes_dir_raw = os.getenv("TASK_TRACKER_DAILY_NOTES_DIR")
@@ -1009,34 +935,35 @@ def cmd_standup_summary(args):
             for task in tasks_data.get("done", [])
         ]
 
-    dos_raw = [
-        task
-        for task in tasks_data.get("all", [])
-        if not task.get("done") and task.get("section") in {"q1", "q2", "today"}
-    ]
-    dos = [_canonical_task_with_lookup(task, task_ids) for task in dos_raw]
+    active = active_records(records)
+    dos_records = [record for record in active if record.section in {"q1", "q2", "today"}]
+    dos = [_canonical_record(record) for record in dos_records]
 
-    overdue_raw = []
-    for task in tasks_data.get("all", []):
-        if task.get("done") or not task.get("due"):
+    overdue_records = []
+    for record in active:
+        if not record.due:
             continue
         try:
-            due_date = datetime.strptime(task.get("due"), "%Y-%m-%d").date()
+            due_date = datetime.strptime(record.due, "%Y-%m-%d").date()
         except ValueError:
             continue
         if due_date < today:
-            overdue_raw.append(task)
-    overdue = [_canonical_task_with_lookup(task, task_ids) for task in overdue_raw]
+            overdue_records.append(record)
+    overdue = [_canonical_record(record) for record in overdue_records]
 
     carryover_suggestions = []
-    for task in overdue_raw:
+    for record in overdue_records:
         carryover_suggestions.append(
             {
-                "title": task.get("title", ""),
+                "task_id": record.canonical_id,
+                "fallback_id": record.fallback_id,
+                "missing_task_id": record.missing_task_id,
+                "fallback_only": record.fallback_only,
+                "title": record.title,
                 "reason": "overdue",
                 "suggestion": "carry-to-today",
-                "due": task.get("due"),
-                "area": task.get("area") or task.get("department") or "Uncategorized",
+                "due": record.due,
+                "area": record.area or record.department or "Uncategorized",
             }
         )
 
@@ -1068,7 +995,7 @@ def cmd_weekly_review_summary(args):
         sys.exit(2)
 
     tasks_data = _safe_load_tasks(args.personal)
-    task_ids = _task_id_lookup(tasks_data)
+    records = _safe_load_task_records(args.personal)
     notes_dir_raw = os.getenv("TASK_TRACKER_DAILY_NOTES_DIR")
 
     done_items: list[dict] = []
@@ -1099,15 +1026,31 @@ def cmd_weekly_review_summary(args):
             except ValueError:
                 continue
             if start_date <= completed_date <= end_date:
-                row = _canonical_task_with_lookup(task, task_ids)
+                matching = [
+                    record for record in records
+                    if record.line_number == task.get("line_number")
+                    and record.raw_line == task.get("raw_line")
+                ]
+                row = _canonical_record(matching[0]) if matching else {
+                    "task_id": task.get("task_id") or task.get("legacy_id"),
+                    "fallback_id": None,
+                    "missing_task_id": task.get("task_id") is None,
+                    "fallback_only": not (task.get("task_id") or task.get("legacy_id")),
+                    "title": task.get("title", ""),
+                    "done": bool(task.get("done")),
+                    "section": task.get("section"),
+                    "area": task.get("area") or task.get("department") or "Uncategorized",
+                    "priority": task.get("priority"),
+                    "due": task.get("due"),
+                    "owner": task.get("owner"),
+                    "goal": task.get("goal"),
+                }
                 row["completed_date"] = completed
                 done_items.append(row)
 
     do_items = []
-    for task in tasks_data.get("all", []):
-        if task.get("done"):
-            continue
-        due_raw = task.get("due")
+    for record in active_records(records):
+        due_raw = record.due
         if due_raw:
             try:
                 due_date = datetime.strptime(due_raw, "%Y-%m-%d").date()
@@ -1115,7 +1058,36 @@ def cmd_weekly_review_summary(args):
                 continue
             if due_date < start_date or due_date > end_date:
                 continue
-        do_items.append(_canonical_task_with_lookup(task, task_ids))
+        do_items.append(_canonical_record(record))
+
+    if not records:
+        for task in tasks_data.get("all", []):
+            if task.get("done"):
+                continue
+            due_raw = task.get("due")
+            if due_raw:
+                try:
+                    due_date = datetime.strptime(due_raw, "%Y-%m-%d").date()
+                except ValueError:
+                    continue
+                if due_date < start_date or due_date > end_date:
+                    continue
+            do_items.append(
+                {
+                    "task_id": task.get("task_id") or task.get("legacy_id"),
+                    "fallback_id": None,
+                    "missing_task_id": task.get("task_id") is None,
+                    "fallback_only": not (task.get("task_id") or task.get("legacy_id")),
+                    "title": task.get("title", ""),
+                    "done": False,
+                    "section": task.get("section"),
+                    "area": task.get("area") or task.get("department") or "Uncategorized",
+                    "priority": task.get("priority"),
+                    "due": task.get("due"),
+                    "owner": task.get("owner"),
+                    "goal": task.get("goal"),
+                }
+            )
 
     payload = _new_schema("weekly-review-summary")
     payload.update(
@@ -1165,8 +1137,8 @@ def cmd_ingest_daily_log(args):
         source = {"type": "stdin"}
 
     parsed_lines = _extract_done_lines(source_content)
-    tasks_data = _safe_load_tasks(args.personal)
-    catalog = _build_task_catalog(tasks_data)
+    records = _safe_load_task_records(args.personal)
+    catalog = _build_task_catalog(records)
     auto_threshold = float(args.auto_threshold)
     review_threshold = float(args.review_threshold)
     if review_threshold > auto_threshold:
@@ -1178,7 +1150,7 @@ def cmd_ingest_daily_log(args):
         for line in parsed_lines
     ]
 
-    counts = {"auto-link": 0, "needs-review": 0, "no-match": 0}
+    counts = {"evidence-link": 0, "needs-review": 0, "no-match": 0}
     for item in matched:
         counts[item["match_metadata"]["decision"]] += 1
 
@@ -1187,13 +1159,13 @@ def cmd_ingest_daily_log(args):
         {
             "source": source,
             "thresholds": {
-                "auto_link": auto_threshold,
+                "evidence_link": auto_threshold,
                 "needs_review": review_threshold,
             },
             "totals": {
                 "input_lines": len(source_content.splitlines()),
                 "parsed_done_lines": len(parsed_lines),
-                "auto_linked": counts["auto-link"],
+                "evidence_linked": counts["evidence-link"],
                 "needs_review": counts["needs-review"],
                 "no_match": counts["no-match"],
             },
@@ -1215,14 +1187,14 @@ def cmd_calendar_sync_primitive(args):
         warnings.append("calendar-events-unavailable")
 
     try:
-        tasks_data = _safe_load_tasks(args.personal)
-        for task in tasks_data.get("all", []):
-            raw = str(task.get("raw_line") or "")
+        records = _safe_load_task_records(args.personal)
+        for record in records:
+            raw = record.raw_line
             if "meeting::" not in raw:
                 continue
             raw_l = raw.lower()
             status = "scheduled"
-            if task.get("done") or "status::done" in raw_l:
+            if record.done or "status::done" in raw_l:
                 status = "done"
             elif "status::canceled" in raw_l:
                 status = "canceled"
@@ -1231,10 +1203,13 @@ def cmd_calendar_sync_primitive(args):
 
             meetings.append(
                 {
-                    "task_id": _task_identifier_bundle(task, _slugify(task.get("title", "")))["task_id"],
-                    "title": task.get("title", ""),
+                    "task_id": record.canonical_id,
+                    "fallback_id": record.fallback_id,
+                    "missing_task_id": record.missing_task_id,
+                    "fallback_only": record.fallback_only,
+                    "title": record.title,
                     "status": status,
-                    "classification": _calendar_classification(task),
+                    "classification": _calendar_classification(record_to_task_dict(record)),
                 }
             )
     except Exception:
@@ -1393,14 +1368,14 @@ def main():
 
     ingest_daily_log_parser = subparsers.add_parser(
         'ingest-daily-log',
-        help='Ingest done lines and map to canonical tasks',
+        help='Report done-line evidence links for canonical tasks',
     )
     ingest_daily_log_parser.add_argument('--file', help='Input log file; default is stdin')
     ingest_daily_log_parser.add_argument(
         '--auto-threshold',
         type=float,
-        default=FUZZY_AUTO_LINK_THRESHOLD,
-        help='Fuzzy score threshold for auto-linking',
+        default=FUZZY_EVIDENCE_LINK_THRESHOLD,
+        help='Fuzzy score threshold for evidence-link suggestions',
     )
     ingest_daily_log_parser.add_argument(
         '--review-threshold',

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -39,6 +39,33 @@ def test_get_archive_dir(tmp_path, monkeypatch):
     assert archive_dir == custom_dir
 
 
+def test_archive_week_removes_multiple_done_lines_bottom_up(tmp_path, monkeypatch):
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 2, 19)
+
+    monkeypatch.setattr(archive, "date", FakeDate)
+
+    objectives = tmp_path / "objectives.md"
+    objectives.write_text("""# Objectives 2026
+
+## Dev
+
+- [x] First completed task ✅ 2026-02-18
+- [x] Second completed task ✅ 2026-02-18
+- [ ] Active task
+""")
+
+    result = archive_week(tasks_file=objectives, personal=False)
+
+    assert result["removed"] == 2
+    updated = objectives.read_text()
+    assert "First completed task" not in updated
+    assert "Second completed task" not in updated
+    assert "- [ ] Active task" in updated
+
+
 def test_consolidate_month_includes_previous_iso_year_week(tmp_path):
     archive_dir = tmp_path / "Done Archive"
     archive_dir.mkdir()

--- a/tests/test_eod_sync.py
+++ b/tests/test_eod_sync.py
@@ -319,3 +319,31 @@ def test_cli_default_is_report_only(tmp_path):
     assert proc.returncode == 0
     assert "Report-only mode" in proc.stdout
     assert weekly.read_text() == original
+
+
+def test_cli_dry_run_wins_over_apply(tmp_path):
+    daily_dir = tmp_path / "daily"
+    daily_dir.mkdir()
+    (daily_dir / "2026-02-19.md").write_text(DAILY_NOTE_PLAIN_DONE)
+    weekly = tmp_path / "Weekly TODOs.md"
+    original = """# Weekly TODOs
+
+- [ ] KPMG audit package — prep + send 📅 2026-02-19 🔺
+"""
+    weekly.write_text(original)
+
+    env = os.environ.copy()
+    env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(daily_dir)
+    env["TASK_TRACKER_WEEKLY_TODOS"] = str(weekly)
+
+    proc = subprocess.run(
+        ["python3", "scripts/eod_sync.py", "--date", "2026-02-19", "--apply", "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert proc.returncode == 0
+    assert "Dry-run mode" in proc.stdout
+    assert weekly.read_text() == original

--- a/tests/test_eod_sync.py
+++ b/tests/test_eod_sync.py
@@ -1,9 +1,10 @@
-"""Tests for eod_sync.py — EOD completion auto-sync."""
+"""Tests for eod_sync.py — EOD completion evidence reporting."""
 
 from __future__ import annotations
 
 import sys
 import os
+import subprocess
 from pathlib import Path
 from datetime import date
 
@@ -200,9 +201,9 @@ DONE_ITEMS_SAMPLE = [
 
 
 class TestBuildSyncPlan:
-    def test_auto_syncs_high_confidence(self):
+    def test_reports_high_confidence_evidence(self):
         plan = sync.build_sync_plan(DONE_ITEMS_SAMPLE, OPEN_TASKS_SAMPLE, "2026-02-19")
-        synced = [r for r in plan if r["status"] == "sync"]
+        synced = [r for r in plan if r["status"] == "evidence"]
         assert len(synced) == 2
 
     def test_skips_no_match(self):
@@ -218,7 +219,7 @@ class TestBuildSyncPlan:
             "- [x] KPMG audit — prep + send ✅ 2026-02-19",  # very similar
         ]
         plan = sync.build_sync_plan(done_items, OPEN_TASKS_SAMPLE, "2026-02-19")
-        synced = [r for r in plan if r["status"] == "sync"]
+        synced = [r for r in plan if r["status"] == "evidence"]
         # The KPMG task should only match once
         kpmg_matched_indices = {r["match"]["line_idx"] for r in synced if r["match"] is not None}
         assert len(kpmg_matched_indices) <= len(synced), "Duplicate match detected"
@@ -290,3 +291,31 @@ class TestApplySyncPlan:
         original_line = lines[0]
         sync.apply_sync_plan(lines, plan, "2026-02-19")
         assert lines[0] == original_line  # original not mutated
+
+
+def test_cli_default_is_report_only(tmp_path):
+    daily_dir = tmp_path / "daily"
+    daily_dir.mkdir()
+    (daily_dir / "2026-02-19.md").write_text(DAILY_NOTE_PLAIN_DONE)
+    weekly = tmp_path / "Weekly TODOs.md"
+    original = """# Weekly TODOs
+
+- [ ] KPMG audit package — prep + send 📅 2026-02-19 🔺
+"""
+    weekly.write_text(original)
+
+    env = os.environ.copy()
+    env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(daily_dir)
+    env["TASK_TRACKER_WEEKLY_TODOS"] = str(weekly)
+
+    proc = subprocess.run(
+        ["python3", "scripts/eod_sync.py", "--date", "2026-02-19"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert proc.returncode == 0
+    assert "Report-only mode" in proc.stdout
+    assert weekly.read_text() == original

--- a/tests/test_objective_parser.py
+++ b/tests/test_objective_parser.py
@@ -187,6 +187,18 @@ def test_remove_task_line_preserves_sibling_tasks():
 """
 
 
+def test_remove_task_line_removes_tab_indented_children():
+    content = """- [x] Parent task
+\t- [ ] Tab child
+- [ ] Sibling task
+"""
+
+    updated = remove_task_line(content, "- [x] Parent task", 1)
+
+    assert updated == """- [ ] Sibling task
+"""
+
+
 def test_remove_task_line_handles_flat_task():
     content = """- [ ] Task one
 - [ ] Task two

--- a/tests/test_objective_parser.py
+++ b/tests/test_objective_parser.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from tasks import _remove_task_line
+from task_lines import remove_task_line
 from utils import detect_format, parse_tasks
 
 
@@ -166,7 +166,7 @@ def test_remove_task_line_removes_parent_and_subtasks():
 - [ ] Sibling objective
 """
 
-    updated = _remove_task_line(content, "- [ ] Parent objective")
+    updated = remove_task_line(content, "- [ ] Parent objective", 2)
 
     assert updated == """## Objectives
 - [ ] Sibling objective
@@ -180,7 +180,7 @@ def test_remove_task_line_preserves_sibling_tasks():
   - [ ] Child B1
 """
 
-    updated = _remove_task_line(content, "- [ ] Parent A")
+    updated = remove_task_line(content, "- [ ] Parent A", 1)
 
     assert updated == """- [ ] Parent B
   - [ ] Child B1
@@ -192,7 +192,7 @@ def test_remove_task_line_handles_flat_task():
 - [ ] Task two
 """
 
-    updated = _remove_task_line(content, "- [ ] Task one")
+    updated = remove_task_line(content, "- [ ] Task one", 1)
 
     assert updated == """- [ ] Task two
 """

--- a/tests/test_task_primitives.py
+++ b/tests/test_task_primitives.py
@@ -139,8 +139,8 @@ def test_ingest_daily_log_plain_bullets_and_exact_matching(tmp_path):
     assert payload["schema_version"] == "v1"
     assert payload["command"] == "ingest-daily-log"
     assert payload["totals"]["parsed_done_lines"] == 2
-    assert payload["totals"]["auto_linked"] == 2
-    assert payload["items"][0]["match_metadata"]["decision"] == "auto-link"
+    assert payload["totals"]["evidence_linked"] == 2
+    assert payload["items"][0]["match_metadata"]["decision"] == "evidence-link"
     assert payload["items"][0]["match_metadata"]["match_type"] in {"normalized-title", "exact-id-or-link"}
     assert payload["items"][1]["match_metadata"]["match_type"] == "exact-id-or-link"
 
@@ -212,11 +212,16 @@ def test_fallback_task_ids_are_unique_and_consistent_across_primitives(tmp_path)
     )
     assert standup.returncode == 0
     standup_payload = json.loads(standup.stdout)
-    standup_duplicate_ids = [
-        item["task_id"] for item in standup_payload["dos"] if item["title"] == "Duplicate title"
+    standup_duplicate_fallback_ids = [
+        item["fallback_id"] for item in standup_payload["dos"] if item["title"] == "Duplicate title"
     ]
-    assert len(standup_duplicate_ids) == 2
-    assert len(set(standup_duplicate_ids)) == 2
+    assert len(standup_duplicate_fallback_ids) == 2
+    assert len(set(standup_duplicate_fallback_ids)) == 2
+    assert all(
+        item["task_id"] is None and item["fallback_only"]
+        for item in standup_payload["dos"]
+        if item["title"] == "Duplicate title"
+    )
 
     week_start = date.today() - timedelta(days=date.today().weekday())
     week_end = week_start + timedelta(days=6)
@@ -237,10 +242,10 @@ def test_fallback_task_ids_are_unique_and_consistent_across_primitives(tmp_path)
     )
     assert weekly.returncode == 0
     weekly_payload = json.loads(weekly.stdout)
-    weekly_duplicate_ids = [
-        item["task_id"] for item in weekly_payload["DO"]["items"] if item["title"] == "Duplicate title"
+    weekly_duplicate_fallback_ids = [
+        item["fallback_id"] for item in weekly_payload["DO"]["items"] if item["title"] == "Duplicate title"
     ]
-    assert standup_duplicate_ids == weekly_duplicate_ids
+    assert standup_duplicate_fallback_ids == weekly_duplicate_fallback_ids
 
     ingest = subprocess.run(
         ["python3", "scripts/tasks.py", "ingest-daily-log"],
@@ -252,8 +257,8 @@ def test_fallback_task_ids_are_unique_and_consistent_across_primitives(tmp_path)
     )
     assert ingest.returncode == 0
     ingest_payload = json.loads(ingest.stdout)
-    mapped_id = ingest_payload["items"][0]["canonical_task"]["task_id"]
-    assert mapped_id == sorted(standup_duplicate_ids)[0]
+    assert ingest_payload["items"][0]["canonical_task"]["task_id"] is None
+    assert ingest_payload["items"][0]["canonical_task"]["fallback_only"] is True
 
 
 def test_ingest_daily_log_strips_time_prefix_before_checkmark(tmp_path):
@@ -272,7 +277,7 @@ def test_ingest_daily_log_strips_time_prefix_before_checkmark(tmp_path):
     payload = json.loads(proc.stdout)
     assert payload["totals"]["parsed_done_lines"] == 1
     assert payload["items"][0]["parsed_title"] == "Ship alpha milestone"
-    assert payload["items"][0]["match_metadata"]["decision"] == "auto-link"
+    assert payload["items"][0]["match_metadata"]["decision"] == "evidence-link"
     assert payload["items"][0]["match_metadata"]["match_type"] == "normalized-title"
 
 
@@ -291,7 +296,7 @@ def test_ingest_daily_log_disambiguates_cross_repo_issue_urls(tmp_path):
     assert proc.returncode == 0
     payload = json.loads(proc.stdout)
     assert payload["totals"]["parsed_done_lines"] == 1
-    assert payload["totals"]["auto_linked"] == 1
-    assert payload["items"][0]["match_metadata"]["decision"] == "auto-link"
+    assert payload["totals"]["evidence_linked"] == 1
+    assert payload["items"][0]["match_metadata"]["decision"] == "evidence-link"
     assert payload["items"][0]["match_metadata"]["match_type"] == "exact-id-or-link"
     assert payload["items"][0]["canonical_task"]["title"] == "Repo B issue 42"


### PR DESCRIPTION
## Summary

108B now makes the identity kernel usable by the surrounding workflow code instead of leaving each command to invent its own task shape. Active task reads go through one parser-backed `TaskRecord` contract, while completion-like fuzzy/title flows are downgraded to evidence/reporting unless an explicit canonical ID mutation is used.

[size/exempt: planned 108B consolidation slice; splitting further would leave parser contract changes separated from the mutation-boundary cleanup and tests that prove the contract]

## What Changed

- `task_records.py` is the shared read contract for identity audit, task primitives, standup summaries, calendar primitives, and weekly summaries.
- `task_lines.py` owns line-number-verified text edits so board mutations do not fall back to raw title/string removal helpers.
- Daily-log ingestion now reports `evidence-link` matches instead of `auto-link`, and EOD sync is report-only by default with legacy Weekly TODO checkbox writes behind `--apply`.
- Standup and docs now reinforce `done <task_id>` semantics and mark fallback IDs as diagnostics only.

## Why

PR #108A landed canonical IDs and ID-only `done`, but nearby workflow surfaces still exposed title/fuzzy completion language and duplicate parser logic. This closes that compatibility gap before 108C adds a completion evidence inbox.

## Verification

- `python3 -m pytest -q` -> 156 passed
- `bash scripts/ci/check-public-hygiene.sh` -> passed
- `markdownlint --disable MD013 MD022 MD025 MD031 MD032 MD060 -- docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md README.md SKILL.md docs/ARCHITECTURE.md docs/CALENDAR_INTEGRATION.md references/eod-sync.md references/task-primitives-schema-v1.md` -> passed
- `git diff --check` -> passed
- `python3 -m py_compile scripts/task_records.py scripts/task_lines.py scripts/task_identity.py scripts/task_transitions.py scripts/tasks.py scripts/standup.py scripts/standup_common.py scripts/archive.py scripts/eod_sync.py` -> passed
- `ce-test-browser mode:pipeline` -> not applicable; no web routes or dev server surface in this CLI/docs change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
