### PR TITLE
fix(tasks): harden identity foundation before evidence inbox

### DIFF
--- a/docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
+++ b/docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
@@ -455,8 +455,9 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 
 1. **PR #108A:** Canonical identity kernel. Land U1 through U5.
 2. **PR #108B:** Parser and mutation consolidation. Land U6.
-3. **PR #108C:** Completion evidence inbox. Land U7.
-4. **Later workflow PR:** Update Lobster/Telegram/standup/weekly/EOD workflows to consume canonical IDs and evidence suggestions.
+3. **PR #108B hardening:** Close the post-108B Oracle P1s before evidence inbox: ledger malformed-line reporting, complete-by-ID rollback around daily-log/board/ledger writes, and weekly archive cleanup through the shared line helper. See `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`.
+4. **PR #108C:** Completion evidence inbox. Land U7.
+5. **Later workflow PR:** Update Lobster/Telegram/standup/weekly/EOD workflows to consume canonical IDs and evidence suggestions.
 
 ---
 
@@ -472,6 +473,7 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 
 - #108A is ready when identity, repair, ledger, ID-only done, recurrence, and docs/hygiene tests pass without candidate or broad-state tests.
 - #108B is ready when standup, weekly, EOD, and primitive summaries consume one canonical task record shape and no write path bypasses the kernel.
+- #108B hardening is ready when malformed ledger lines are no longer silent, completion rollback covers daily-log and board write failures, and weekly stale cleanup uses line-number-verified removal.
 - #108C is ready when evidence candidates can be created, deduped, decided, retried, and applied only through ID-only done.
 
 ---

--- a/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
+++ b/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
@@ -424,6 +424,7 @@ The important boundary is that read surfaces may consume fallback diagnostics, b
 | Output schema changes break Lobster consumers | Preserve existing fields where possible and add identity diagnostics rather than renaming stable fields casually. |
 | Shared helper placement creates circular imports | Keep pure read helpers in `scripts/task_records.py` and pure line-edit helpers in `scripts/task_lines.py`, with workflow modules depending downward. |
 | Fallback IDs leak back into mutation commands | Test `done <fallback-id>` and duplicate-title cases explicitly. |
+| Evidence inbox builds on remaining P1 foundation gaps | Close `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md` before starting 108C. |
 
 ---
 
@@ -436,6 +437,7 @@ The important boundary is that read surfaces may consume fallback diagnostics, b
 5. Centralize active-board line mutation helpers.
 6. Make EOD/daily-log fuzzy matching report-only by default.
 7. Update docs/help and run the full local verification suite.
+8. Follow up with 108B hardening before 108C: malformed ledger reporting, completion rollback hardening, and weekly archive cleanup through shared line helpers.
 
 ---
 

--- a/docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md
+++ b/docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md
@@ -1,0 +1,122 @@
+---
+title: fix: harden 108B task identity foundation before evidence inbox
+type: fix
+status: active
+date: 2026-05-21
+origin: oracle-progress-review-after-108a-108b
+---
+
+# fix: harden 108B task identity foundation before evidence inbox
+
+## Summary
+
+Harden the landed 108A/108B foundation before starting 108C. Oracle found no P0 blocker and agreed 108C is still the right next product slice, but flagged three P1 risks that should be closed first: tolerant ledger reads can hide malformed audit history, `complete_by_id()` does not restore all side effects when board writes fail after completion logging, and weekly archive cleanup still has a raw string removal path instead of the shared line-number-verified helper.
+
+This plan is intentionally smaller than 108C. It does not add completion candidates or new evidence sources. It makes the existing mutation/audit boundary safer so 108C can build on it.
+
+## Requirements
+
+- R1. Ledger reads used by task-tracker code must not silently discard malformed JSONL. They must surface malformed lines as structured warnings or explicit errors.
+- R2. ID-only completion must restore board, daily-log, and ledger snapshots if any write after daily-log append fails.
+- R3. Weekly archive stale-line cleanup must use the shared `task_lines.remove_task_line()` helper with raw-line and line-number verification.
+- R4. The hardening must preserve the current contract: board markdown remains current state, ledger remains audit trail, daily notes remain user-facing completion log.
+- R5. Public docs/plans should reflect that these P1s are closed before 108C and that 108C remains evidence-inbox-only.
+
+## Scope Boundaries
+
+- Do not implement 108C completion candidates.
+- Do not add Gmail, calendar, session-log, Telegram, or Lobster cron evidence ingestion.
+- Do not make ledger replay the source of truth.
+- Do not add broad state transitions, weekly UX redesign, or standup decision UX.
+- Do not remove the legacy `eod_sync.py --apply` path in this PR; it remains explicitly legacy and non-canonical.
+
+## Technical Decisions
+
+- Keep `read_events()` backward-compatible for callers by returning only valid events by default, but add a strict/reporting API so audit-sensitive callers and future 108C code can detect malformed lines.
+- Treat board write failure the same as ledger append failure: restore all snapshots captured before mutation and return a structured error.
+- Sort weekly stale cleanup removals bottom-up so line numbers remain stable across multiple deletions in one pass.
+
+## Implementation Units
+
+### U1. Ledger Malformation Reporting
+
+**Files:**
+
+- Modify: `scripts/task_ledger.py`
+- Modify: `tests/test_task_ledger.py`
+
+**Approach:**
+
+- Introduce structured malformed-line reporting for JSONL reads.
+- Preserve existing tolerant reads where compatibility requires it, but expose a strict option or companion function that raises/returns warnings.
+- Ensure malformed lines include enough context for repair: path, line number, message, and raw line.
+
+**Test scenarios:**
+
+- Tolerant read returns valid events and exposes/report malformed line metadata.
+- Strict read fails or returns an error when malformed JSONL is present.
+- Empty and missing ledger files still behave as empty event streams.
+
+### U2. Completion Rollback Hardening
+
+**Files:**
+
+- Modify: `scripts/task_transitions.py`
+- Modify: `tests/test_task_transitions.py`
+
+**Approach:**
+
+- Wrap daily-log append, board write, and ledger append in one guarded write section after snapshots are captured.
+- If board write fails after daily-log append, restore the daily log and ledger snapshots as well as the board snapshot.
+- If restore itself fails, report the original error plus restore failure details rather than pretending the mutation succeeded.
+
+**Test scenarios:**
+
+- Simulated board write failure after daily-log append leaves board unchanged and removes/restores the daily log.
+- Ledger append failure still restores board and daily log.
+- Successful completion still writes daily log, board mutation, and ledger event once.
+
+### U3. Weekly Archive Cleanup Uses Shared Line Helper
+
+**Files:**
+
+- Modify: `scripts/weekly_review.py`
+- Modify: `tests/test_weekly_review.py`
+
+**Approach:**
+
+- Replace raw `content.replace(raw_line + "\n", "", 1)` cleanup with `remove_task_line(content, raw_line, line_number)`.
+- Process stale done tasks bottom-up to avoid line-number drift.
+- Return the same removed count semantics.
+
+**Test scenarios:**
+
+- Cleanup removes a checked parent and its indented children.
+- Cleanup handles tab-indented children through the shared helper.
+- Cleanup does not remove a duplicated sibling line when the stored line number/raw line no longer matches.
+
+### U4. Plan and Documentation Alignment
+
+**Files:**
+
+- Modify: `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- Modify: `docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md`
+- Add: `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`
+
+**Approach:**
+
+- Add concise follow-up notes that 108B hardening closes the Oracle P1s before 108C.
+- Keep 108C scoped to completion evidence inbox only.
+
+**Test scenarios:**
+
+- Markdown lint passes for changed plan docs.
+- Docs do not imply 108C should include Gmail/calendar/session/Lobster ingestion or auto-mutation.
+
+## Verification
+
+- `python3 -m pytest -q tests/test_task_ledger.py tests/test_task_transitions.py tests/test_weekly_review.py`
+- `python3 -m pytest -q`
+- `bash scripts/ci/check-public-hygiene.sh`
+- `markdownlint` on changed plan docs when available
+- `git diff --check`

--- a/scripts/task_ledger.py
+++ b/scripts/task_ledger.py
@@ -5,12 +5,29 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
+from dataclasses import dataclass
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from utils import get_tasks_file
+
+
+@dataclass(frozen=True)
+class MalformedLedgerLine:
+    path: str
+    line_number: int
+    message: str
+    raw_line: str
+
+
+class MalformedLedgerError(ValueError):
+    def __init__(self, malformed: list[MalformedLedgerLine]):
+        self.malformed = malformed
+        summary = ", ".join(f"{item.path}:{item.line_number}: {item.message}" for item in malformed)
+        super().__init__(f"Malformed ledger JSONL line(s): {summary}")
 
 
 def ledger_path(tasks_file: Path | None = None) -> Path:
@@ -58,16 +75,38 @@ def append_event(event: dict[str, Any], path: Path | None = None) -> dict[str, A
     return event
 
 
-def read_events(path: Path | None = None) -> list[dict[str, Any]]:
+def read_events_report(path: Path | None = None) -> tuple[list[dict[str, Any]], list[MalformedLedgerLine]]:
     target = path or ledger_path()
     if not target.exists():
-        return []
+        return [], []
     events: list[dict[str, Any]] = []
-    for line in target.read_text(encoding="utf-8").splitlines():
+    malformed: list[MalformedLedgerLine] = []
+    for line_number, line in enumerate(target.read_text(encoding="utf-8").splitlines(), start=1):
         if not line.strip():
             continue
         try:
             events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as exc:
+            malformed.append(
+                MalformedLedgerLine(
+                    path=str(target),
+                    line_number=line_number,
+                    message=str(exc),
+                    raw_line=line,
+                )
+            )
+    return events, malformed
+
+
+def read_events(path: Path | None = None, *, strict: bool = False) -> list[dict[str, Any]]:
+    events, malformed = read_events_report(path)
+    if malformed:
+        if strict:
+            raise MalformedLedgerError(malformed)
+        warnings.warn(
+            f"Ignored {len(malformed)} malformed ledger JSONL line(s); "
+            "use read_events_report() or strict=True for details.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     return events

--- a/scripts/task_transitions.py
+++ b/scripts/task_transitions.py
@@ -61,6 +61,14 @@ def _restore_snapshots(snapshots: dict[Path, tuple[bool, str]]) -> None:
             path.unlink()
 
 
+def _restore_after_failure(snapshots: dict[Path, tuple[bool, str]]) -> str | None:
+    try:
+        _restore_snapshots(snapshots)
+    except OSError as exc:
+        return str(exc)
+    return None
+
+
 def _daily_log_file() -> Path | None:
     raw_dir = os.getenv("TASK_TRACKER_DONE_LOG_DIR") or os.getenv("TASK_TRACKER_DAILY_NOTES_DIR")
     if not raw_dir:
@@ -174,34 +182,41 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
     if ledger_snapshot is not None:
         snapshots[ledger_file] = ledger_snapshot
 
-    logged = log_task_completed(
-        title=record.title,
-        section=record.section,
-        area=record.area,
-        due=due_value,
-        recur=recur_value or None,
-        context={"task_id": task_id, "source": source},
-    )
-    if not logged:
-        return {
-            "ok": False,
-            "error": {
-                "code": "completion-log-failed",
-                "message": "Daily-note completion log failed; active board was not changed.",
-            },
-        }
-
-    tasks_file.write_text(new_content, encoding="utf-8")
+    write_stage = "completion-log"
     try:
+        logged = log_task_completed(
+            title=record.title,
+            section=record.section,
+            area=record.area,
+            due=due_value,
+            recur=recur_value or None,
+            context={"task_id": task_id, "source": source},
+        )
+        if not logged:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "completion-log-failed",
+                    "message": "Daily-note completion log failed; active board was not changed.",
+                },
+            }
+
+        write_stage = "board-write"
+        tasks_file.write_text(new_content, encoding="utf-8")
+        write_stage = "ledger-append"
         append_event(event, path=ledger_path(tasks_file))
     except OSError as exc:
-        _restore_snapshots(snapshots)
+        restore_error = _restore_after_failure(snapshots)
+        code = "ledger-append-failed" if write_stage == "ledger-append" else "task-state-write-failed"
+        error = {
+            "code": code,
+            "message": f"Task completion write failed; snapshots were restored: {exc}",
+        }
+        if restore_error:
+            error["restore_error"] = restore_error
         return {
             "ok": False,
-            "error": {
-                "code": "ledger-append-failed",
-                "message": f"Ledger append failed after board write; board was restored: {exc}",
-            },
+            "error": error,
         }
     return {"ok": True, "task_id": task_id, "title": record.title, "event": event}
 

--- a/scripts/weekly_review.py
+++ b/scripts/weekly_review.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from daily_notes import extract_completed_actions, extract_completed_tasks
+from task_lines import remove_task_line
 from utils import (
     get_tasks_file,
     ARCHIVE_DIR,
@@ -235,10 +236,12 @@ def _clean_stale_done_lines(tasks_file: Path, done_tasks: list[dict]) -> int:
 
     content = tasks_file.read_text()
     removed = 0
-    for task in done_tasks:
+    for task in sorted(done_tasks, key=lambda item: item.get('line_number') or 0, reverse=True):
         raw_line = task.get('raw_line', '')
-        if raw_line and raw_line in content:
-            content = content.replace(raw_line + '\n', '', 1)
+        line_number = task.get('line_number')
+        updated = remove_task_line(content, raw_line, line_number)
+        if updated is not None:
+            content = updated
             removed += 1
 
     if removed:

--- a/tests/test_task_ledger.py
+++ b/tests/test_task_ledger.py
@@ -1,13 +1,14 @@
 import json
 import sys
+import pytest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from task_ledger import read_events
+from task_ledger import MalformedLedgerError, read_events, read_events_report
 
 
-def test_read_events_skips_malformed_jsonl_lines(tmp_path):
+def test_read_events_warns_when_skipping_malformed_jsonl_lines(tmp_path):
     ledger = tmp_path / "events.jsonl"
     ledger.write_text(
         json.dumps({"event_type": "ok", "event_id": "evt_1"}) + "\n"
@@ -15,6 +16,33 @@ def test_read_events_skips_malformed_jsonl_lines(tmp_path):
         + json.dumps({"event_type": "ok", "event_id": "evt_2"}) + "\n"
     )
 
-    events = read_events(ledger)
+    with pytest.warns(RuntimeWarning, match="malformed ledger JSONL"):
+        events = read_events(ledger)
 
     assert [event["event_id"] for event in events] == ["evt_1", "evt_2"]
+
+
+def test_read_events_report_returns_malformed_line_details(tmp_path):
+    ledger = tmp_path / "events.jsonl"
+    ledger.write_text(
+        json.dumps({"event_type": "ok", "event_id": "evt_1"}) + "\n"
+        '{"event_type":"truncated"\n'
+    )
+
+    events, malformed = read_events_report(ledger)
+
+    assert [event["event_id"] for event in events] == ["evt_1"]
+    assert len(malformed) == 1
+    assert malformed[0].path == str(ledger)
+    assert malformed[0].line_number == 2
+    assert malformed[0].raw_line == '{"event_type":"truncated"'
+
+
+def test_read_events_strict_raises_on_malformed_jsonl(tmp_path):
+    ledger = tmp_path / "events.jsonl"
+    ledger.write_text('{"event_type":"truncated"\n')
+
+    with pytest.raises(MalformedLedgerError) as exc:
+        read_events(ledger, strict=True)
+
+    assert exc.value.malformed[0].line_number == 1

--- a/tests/test_task_transitions.py
+++ b/tests/test_task_transitions.py
@@ -2,6 +2,13 @@ import json
 import os
 import subprocess
 from datetime import datetime
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import task_transitions
+import task_records
 
 
 def _env(tmp_path, work):
@@ -212,6 +219,42 @@ def test_done_restores_board_and_completion_log_when_ledger_append_fails(tmp_pat
     assert payload["error"]["code"] == "ledger-append-failed"
     assert work.read_text() == original
     assert not list((tmp_path / "daily").glob("*.md"))
+
+
+def test_done_restores_completion_log_when_board_write_fails(tmp_path, monkeypatch):
+    work = tmp_path / "Work Tasks.md"
+    original = """# Work
+
+## 🔴 Q1
+- [ ] **Ship milestone** task_id::tsk_ship area:: Delivery
+"""
+    work.write_text(original)
+    env = _env(tmp_path, work)
+    monkeypatch.setenv("TASK_TRACKER_WORK_FILE", env["TASK_TRACKER_WORK_FILE"])
+    monkeypatch.setenv("TASK_TRACKER_DAILY_NOTES_DIR", env["TASK_TRACKER_DAILY_NOTES_DIR"])
+    monkeypatch.setenv("TASK_TRACKER_DONE_LOG_DIR", env["TASK_TRACKER_DONE_LOG_DIR"])
+    monkeypatch.setenv("TASK_TRACKER_LEDGER_FILE", env["TASK_TRACKER_LEDGER_FILE"])
+    monkeypatch.setattr(task_records, "get_tasks_file", lambda personal=False: (work, "obsidian"))
+
+    original_write_text = Path.write_text
+    failed = False
+
+    def fail_first_board_write(path_obj, content, *args, **kwargs):
+        nonlocal failed
+        if path_obj == work and not failed:
+            failed = True
+            raise OSError("simulated board write failure")
+        return original_write_text(path_obj, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_first_board_write)
+
+    result = task_transitions.complete_by_id("tsk_ship")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "task-state-write-failed"
+    assert work.read_text() == original
+    assert not list((tmp_path / "daily").glob("*.md"))
+    assert (tmp_path / "events.jsonl").read_text() == ""
 
 
 def test_done_handles_date_named_daily_log_directory(tmp_path):

--- a/tests/test_weekly_review.py
+++ b/tests/test_weekly_review.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from weekly_review import _clean_stale_done_lines
+
+
+def test_clean_stale_done_lines_removes_parent_and_children(tmp_path):
+    tasks_file = tmp_path / "Work Tasks.md"
+    tasks_file.write_text("""# Work
+
+## 🔴 Q1
+- [x] **Completed parent** task_id::tsk_done
+  - [ ] Child note
+- [ ] **Active sibling** task_id::tsk_active
+""")
+
+    removed = _clean_stale_done_lines(
+        tasks_file,
+        [
+            {
+                "raw_line": "- [x] **Completed parent** task_id::tsk_done",
+                "line_number": 4,
+            }
+        ],
+    )
+
+    content = tasks_file.read_text()
+    assert removed == 1
+    assert "Completed parent" not in content
+    assert "Child note" not in content
+    assert "Active sibling" in content
+
+
+def test_clean_stale_done_lines_handles_tab_indented_children(tmp_path):
+    tasks_file = tmp_path / "Work Tasks.md"
+    tasks_file.write_text("""# Work
+
+## 🔴 Q1
+- [x] **Completed parent** task_id::tsk_done
+\t- [ ] Tab child
+- [ ] **Active sibling** task_id::tsk_active
+""")
+
+    removed = _clean_stale_done_lines(
+        tasks_file,
+        [
+            {
+                "raw_line": "- [x] **Completed parent** task_id::tsk_done",
+                "line_number": 4,
+            }
+        ],
+    )
+
+    content = tasks_file.read_text()
+    assert removed == 1
+    assert "Completed parent" not in content
+    assert "Tab child" not in content
+    assert "Active sibling" in content
+
+
+def test_clean_stale_done_lines_refuses_shifted_duplicate_raw_line(tmp_path):
+    tasks_file = tmp_path / "Work Tasks.md"
+    duplicate_line = "- [x] **Duplicate done** task_id::tsk_done"
+    original = f"""# Work
+
+## 🔴 Q1
+{duplicate_line}
+- [ ] **Inserted line changed numbering** task_id::tsk_inserted
+{duplicate_line}
+"""
+    tasks_file.write_text(original)
+
+    removed = _clean_stale_done_lines(
+        tasks_file,
+        [
+            {
+                "raw_line": duplicate_line,
+                "line_number": 5,
+            }
+        ],
+    )
+
+    assert removed == 0
+    assert tasks_file.read_text() == original


### PR DESCRIPTION
## Summary

This closes the post-108B hardening gap before the completion evidence inbox. The identity foundation now reports malformed ledger history, restores daily-log/board/ledger snapshots when completion writes fail, and routes weekly stale cleanup through the same line-number-verified task-line helper as the ID-only mutation kernel.

## What Changed

- Ledger reads now expose malformed JSONL through `read_events_report()` and can fail strict reads with `MalformedLedgerError`; tolerant reads warn instead of silently discarding bad lines.
- `complete_by_id()` now treats daily-log append, board write, and ledger append as one guarded write section with snapshot restore on filesystem failure.
- `weekly_review.py` stale checked-line cleanup now uses `task_lines.remove_task_line()` and processes lines bottom-up.
- 108A/108B plan docs now record this hardening slice as the required preflight before 108C.

## Why

Oracle found no P0 blocker after 108A/108B, but called out these P1 risks as worth closing before adding the 108C evidence inbox. The inbox should build on one honest audit reader and one rollback-safe ID-only completion path.

## Verification

- `python3 -m pytest -q tests/test_task_ledger.py tests/test_task_transitions.py tests/test_weekly_review.py` -> 24 passed
- `python3 -m pytest -q tests/test_task_ledger.py tests/test_task_transitions.py tests/test_weekly_review.py tests/test_archive.py tests/test_task_primitives.py` -> 36 passed
- `python3 -m pytest -q` -> 167 passed
- `bash scripts/ci/check-public-hygiene.sh` -> passed
- `markdownlint --disable MD013 MD022 MD025 MD031 MD032 MD060 -- docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md` -> passed
- `python3 -m py_compile scripts/task_ledger.py scripts/task_transitions.py scripts/weekly_review.py` -> passed
- `git diff --check` -> passed
- `ce-test-browser mode:pipeline` -> not applicable; CLI/docs-only change with no browser route

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
