### PR TITLE
feat(tasks): add completion evidence inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ python3 scripts/weekly_review.py
 - Task list/add/done workflows for work and personal boards
 - Canonical task identity audit/repair with inline `task_id::` metadata
 - Append-only JSONL event ledger for repairs and ID-based completions
+- Durable completion evidence inbox for review/confirm/reject/snooze decisions
 - Daily standup summaries (`standup.py`, `personal_standup.py`)
 - Weekly review + archive workflows (`weekly_review.py`, `archive.py`)
 - Backlog and delegated-task hygiene
 - Action extraction from notes (`extract_tasks.py`)
-- End-of-day evidence reporting retained, with legacy Weekly TODO writes behind `--apply`
+- End-of-day evidence reporting retained, with legacy Weekly TODO writes behind
+  `--apply`
 - Weekly transclusion refresh for Obsidian (`update_weekly_embeds.py`)
 
 ## Compatibility
@@ -49,6 +51,10 @@ matching remains useful for read-only review and migration diagnostics, but
 write paths block when they cannot resolve exactly one canonical task.
 Fallback IDs may appear in JSON output for diagnostics; they are not valid
 mutation targets.
+
+Completion evidence candidates are suggestions stored in the ledger. Scanning
+daily-log/EOD-style evidence never changes active tasks. Candidate confirmation
+uses the same canonical-ID completion path as `tasks.py done`.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,8 @@ metadata: {"openclaw":{"emoji":"📋","requires":{"env":["TASK_TRACKER_WORK_FILE
 
 # Task Tracker
 
-Personal task management for work + personal workflows, with daily standups and weekly reviews.
+Personal task management for work + personal workflows, with daily standups and
+weekly reviews.
 
 ## When to Use
 
@@ -18,7 +19,9 @@ Use this skill when the user asks to:
 - Add, list, update, or complete tasks
 - Check blockers or due dates
 - Extract actions from meeting notes
-- Report completed daily items against weekly todos without changing canonical task state
+- Report completed daily items against weekly todos without changing canonical
+  task state
+- Review completion evidence candidates before confirming task completion
 
 ## Quick Start
 
@@ -83,7 +86,13 @@ python3 scripts/tasks.py identity-audit
 python3 scripts/tasks.py identity-repair --apply
 python3 scripts/tasks.py done "tsk_example"
 python3 scripts/tasks.py --personal done "tsk_personal"
+python3 scripts/tasks.py completion-candidates scan --file /tmp/done-log.md
+python3 scripts/tasks.py completion-candidates list
+python3 scripts/tasks.py completion-candidates confirm cand_example --task-id tsk_example
 ```
+
+Completion candidates are evidence suggestions. Scanning does not mutate active
+tasks; confirmation must resolve to a canonical `task_id::`.
 
 ### Backlog ops
 
@@ -145,7 +154,9 @@ Detailed docs moved to `references/`:
 
 ## Compatibility Notes
 
-- Active task mutations require canonical `task_id::` values; fallback IDs are diagnostics only.
-- `scripts/eod_sync.py` is report-only by default. `--apply` is a legacy Weekly TODO checkbox helper and does not complete canonical tasks.
+- Active task mutations require canonical `task_id::` values; fallback IDs are
+  diagnostics only.
+- `scripts/eod_sync.py` is report-only by default. `--apply` is a legacy Weekly
+  TODO checkbox helper and does not complete canonical tasks.
 - Legacy file fallback (`TASK_TRACKER_LEGACY_FILE`) is still supported.
 - Migration guidance remains available in `references/migration.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,6 +278,10 @@ sequenceDiagram
 | `identity-audit` | | Report missing, duplicate, and malformed task IDs without writing |
 | `identity-repair` | `--apply` | Add safe missing `task_id::` metadata |
 | `ingest-daily-log` | `--file PATH` | Report completion evidence links; no task writes |
+| `completion-candidates scan` | `--file PATH`, `--date YYYY-MM-DD` | Persist completion evidence candidates; no task writes |
+| `completion-candidates list/show` | `--all`, `--mark-shown` | Review candidate inbox and event history |
+| `completion-candidates confirm` | `--task-id TASK_ID` | Complete through canonical ID-only `done` semantics |
+| `completion-candidates reject/duplicate/snooze` | `--reason`, `--of`, `--until YYYY-MM-DD` | Record candidate decisions without task writes |
 | `blockers` | `--person NAME` | Show blocking tasks |
 | `archive` | | Archive done tasks to quarterly file |
 
@@ -341,6 +345,10 @@ sequenceDiagram
 | `tasks.py done` | Task board, daily notes | Task board (remove/update line), daily note (append) |
 | `tasks.py identity-audit` | Task board | — |
 | `tasks.py ingest-daily-log` | Task board, done text | — |
+| `tasks.py completion-candidates scan` | Task board, done text, ledger | Ledger candidate events |
+| `tasks.py completion-candidates list/show` | Ledger | Ledger only with `--mark-shown` |
+| `tasks.py completion-candidates confirm` | Ledger, task board, daily notes | Task board, daily note, ledger |
+| `tasks.py completion-candidates reject/duplicate/snooze` | Ledger | Ledger candidate events |
 | `tasks.py archive` | Daily notes | Quarterly archive |
 | `standup.py` | Task board, daily notes, calendar | — |
 | `personal_standup.py` | Task board, daily notes, calendar | — |
@@ -355,6 +363,8 @@ sequenceDiagram
 - Priority escalation is read-only — task files are never mutated for display
 - Fuzzy/title evidence is read-only by default and cannot complete canonical tasks
 - Fallback IDs in JSON are diagnostics only; writes require `task_id::` or readable legacy `id::`
+- Completion candidates are suggestions until confirmed through the canonical
+  ID-only completion path
 
 ---
 

--- a/docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md
+++ b/docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md
@@ -1,0 +1,359 @@
+---
+title: feat: add completion evidence inbox
+type: feat
+status: active
+date: 2026-05-21
+origin: docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
+---
+
+# feat: add completion evidence inbox
+
+## Summary
+
+Build PR #108C as the narrow completion evidence inbox promised by the 108A/108B sequence. The inbox turns daily-log and EOD-style completion evidence into reviewable candidates, dedupes repeated scans, and applies confirmed completions only through the ID-only `complete_by_id()` path. It must not add Gmail, calendar, session-log, Telegram, Lobster cron wiring, standup UX redesign, or fuzzy/title auto-mutation.
+
+**Target repo:** task-tracker-openclaw-skill. Paths in this plan are repo-relative.
+
+---
+
+## Problem Frame
+
+108A landed the canonical identity kernel: `task_id::`, identity audit/repair, ID-only `done`, and append-only ledger events for repair/done. 108B consolidated parsing around `TaskRecord`, moved board line edits into line-number-verified helpers, and made fuzzy/EOD flows evidence-only by default. The hardening PR then closed the main P1 risks before candidate work: malformed ledger reads are visible, `complete_by_id()` restores snapshots on write failure, and weekly stale cleanup uses the shared line helper.
+
+The next missing piece is a safe place for "I probably did this" evidence to accumulate without pretending the evidence completed a task. Today `tasks.py ingest-daily-log` can rank matches, but the output is ephemeral. A user or agent has no durable inbox to review, reject, snooze, dedupe, or confirm later. 108C should add that inbox while preserving the source-of-truth boundary: active board markdown is current state; the ledger is audit/candidate history; daily notes are human-facing evidence.
+
+---
+
+## Requirements
+
+- R1. Evidence scans must never mutate the active board, daily completion log, or canonical task state.
+- R2. Candidate state must be durable and reconstructable from append-only ledger events.
+- R3. Candidate IDs must be stable across repeated scans of the same source evidence, so rescanning is idempotent.
+- R4. Candidate confirmation must require exactly one canonical task ID and must call `complete_by_id()` or the same ID-only transition path.
+- R5. Fuzzy, normalized-title, and fallback-only matches may rank suggestions but must not be confirmable without an explicit canonical task ID.
+- R6. Candidate lifecycle must distinguish at least: `new`, `shown`, `confirmed`, `rejected`, `snoozed`, `duplicate`, `expired`, and `apply_failed`.
+- R7. Apply failure must be recorded durably and leave the candidate retryable.
+- R8. Malformed ledger history must block candidate state reconstruction or surface a degraded/error payload; it must not silently produce a clean inbox.
+- R9. The first 108C slice may consume daily-log / existing EOD-style evidence only.
+- R10. Public docs and command help must make clear that this is an evidence inbox, not auto-completion automation.
+
+**Origin traceability:** This implements the deferred 108C slice from `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`, especially U7: "Evidence Inbox, Suggestions Only." It also relies on the hardening preflight in `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Candidate creation from explicit input files/stdin using existing daily-log parsing semantics.
+- Candidate creation from local daily note completion logs for a bounded date/window.
+- Candidate dedupe and state reconstruction from ledger events.
+- Candidate list/show JSON commands for agents and CLI users.
+- Candidate confirm/reject/snooze commands.
+- Confirmation through canonical ID-only completion.
+- Tests proving scan/list/confirm/reject/snooze behavior and failure semantics.
+
+### Deferred to Follow-Up Work
+
+- Gmail, calendar, session-log, Telegram DONEs, and Lobster cron ingestion.
+- Morning standup and EOD UX redesign.
+- Bulk confirm or auto-confirm.
+- Backlog/delegation/frozen/drop state transitions.
+- Ledger replay as active-board source of truth.
+- Removing the legacy `eod_sync.py --apply` weekly TODO write mode.
+
+### Out of Scope
+
+- Any title, fuzzy, fallback ID, quick ID, or list-position mutation.
+- Any change that makes Weekly TODOs canonical task truth.
+- Any candidate source that requires external credentials.
+
+---
+
+## Assumptions
+
+- The ledger can store candidate lifecycle events alongside state transition events using `new_event()` with distinct `event_type` values.
+- Candidate current state can be derived by replaying candidate events in timestamp/file order; no separate database is needed for this slice.
+- Existing `ingest-daily-log` matching output is a useful input shape, but 108C may wrap/rename its internal concepts so fuzzy evidence is described as `suggested_match`, not permission to mutate.
+- The first implementation should prefer JSON-first CLI output because the main consumers are agents and workflow scripts.
+
+---
+
+## Key Technical Decisions
+
+- **Use the ledger as the durable candidate event store.** This avoids adding a second state file while preserving append-only auditability. Candidate state is projection, not source of task truth.
+- **Use stable candidate IDs derived from evidence identity, not task match identity alone.** The same done line should dedupe even if match ranking changes after task titles are edited.
+- **Store source pointers minimally.** Daily-note evidence should record source type, path/date when available, line number when available, raw summary, normalized summary, and redacted/machine-parseable match metadata. Do not copy whole daily notes into ledger events.
+- **Make exact canonical ID evidence the only pre-confirmed match class.** Fuzzy/title matches can suggest a canonical ID, but confirmation should still require that ID explicitly or by selecting the candidate with an unambiguous canonical `matched_task_id`.
+- **Block on malformed ledger reads for candidate commands.** Candidate state built from partial event history is worse than a loud degraded result.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+stateDiagram-v2
+    [*] --> new: scan evidence
+    new --> shown: list/show
+    new --> confirmed: confirm with canonical task_id
+    shown --> confirmed: confirm with canonical task_id
+    new --> rejected: reject
+    shown --> rejected: reject
+    new --> snoozed: snooze until date/window
+    shown --> snoozed: snooze until date/window
+    snoozed --> shown: snooze expires
+    new --> duplicate: duplicate of existing candidate
+    confirmed --> apply_failed: complete_by_id fails
+    apply_failed --> confirmed: retry confirm succeeds
+    confirmed --> [*]
+    rejected --> [*]
+    expired --> [*]
+```
+
+```mermaid
+flowchart TD
+    Evidence["Daily log / EOD-style evidence"] --> Scan["completion-candidates scan"]
+    Scan --> Match["TaskRecord match ranking"]
+    Match --> Events["candidate_* ledger events"]
+    Events --> Inbox["candidate projection"]
+    Inbox --> Decision["confirm/reject/snooze"]
+    Decision -->|confirm with canonical ID| Done["complete_by_id()"]
+    Done --> Board["Markdown active board"]
+    Done --> Ledger["state_transition ledger event"]
+    Decision --> Events
+```
+
+---
+
+## Implementation Units
+
+### U1. Candidate Event Model and Projection
+
+**Goal:** Add a durable candidate lifecycle model backed by append-only ledger events.
+
+**Requirements:** R2, R3, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `scripts/completion_candidates.py`
+- Modify: `scripts/task_ledger.py`
+- Test: `tests/test_completion_candidates.py`
+- Test: `tests/test_task_ledger.py`
+
+**Approach:**
+
+- Define candidate event types such as `candidate_seen`, `candidate_shown`, `candidate_confirmed`, `candidate_rejected`, `candidate_snoozed`, `candidate_duplicate`, `candidate_expired`, and `candidate_apply_failed`.
+- Add helpers that read candidate events with strict ledger parsing and project current candidate state.
+- Generate stable `candidate_id` values from source type, source pointer, normalized evidence summary, and optional evidence timestamp/line number.
+- Keep candidate records separate from active task records: candidates may reference `matched_task_id`, but they are not tasks.
+
+**Patterns to follow:**
+
+- `scripts/task_ledger.py` for event envelope and strict malformed-line handling.
+- `scripts/task_records.py` for canonical task identity fields and fallback diagnostics.
+
+**Test scenarios:**
+
+- Scanning the same evidence twice produces one active candidate projection.
+- A malformed ledger line causes candidate projection to fail loudly or return a degraded JSON error.
+- A candidate with repeated lifecycle events projects to the latest terminal state.
+- Candidate projection preserves source pointer, normalized summary, match metadata, and status.
+
+**Verification:**
+
+- Candidate state can be reconstructed from ledger events without reading or mutating the active board.
+
+### U2. Evidence Scan From Daily Log / Existing Ingest Semantics
+
+**Goal:** Convert daily-log/EOD-style evidence into candidates without mutating task truth.
+
+**Requirements:** R1, R3, R5, R9
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `scripts/completion_candidates.py`
+- Modify: `scripts/tasks.py`
+- Test: `tests/test_completion_candidates.py`
+- Test: `tests/test_task_primitives.py`
+
+**Approach:**
+
+- Reuse or extract the existing done-line parsing and `TaskRecord` match-ranking behavior from `tasks.py ingest-daily-log`.
+- Expose a candidate scan path that accepts `--file`, stdin, and a daily-note date/window input.
+- Store fuzzy/title results as `suggested_match` metadata rather than `evidence-link` instructions.
+- Treat fallback-only matches as review-only suggestions with no confirmable task ID.
+- Avoid changing `ingest-daily-log` output unless needed for clarity; if changed, preserve a compatibility path or update schema docs and tests.
+
+**Test scenarios:**
+
+- Exact canonical ID evidence creates a candidate with `matched_task_id`.
+- Normalized-title evidence creates a candidate with a suggested match but no auto-apply.
+- Fuzzy evidence creates a candidate in review state with score metadata.
+- Fallback-only evidence creates a candidate that cannot be confirmed without a supplied canonical ID.
+- Re-running scan with the same file/stdin content does not create duplicate active candidates.
+
+**Verification:**
+
+- Scans append candidate events only; active board, daily note completion log, and task state transition events remain unchanged.
+
+### U3. Candidate CLI Commands
+
+**Goal:** Add JSON-first CLI commands for scanning, listing, showing, and deciding candidates.
+
+**Requirements:** R1, R4, R6, R7, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `scripts/tasks.py`
+- Modify: `references/commands.md`
+- Modify: `references/task-primitives-schema-v1.md`
+- Test: `tests/test_completion_candidates.py`
+
+**Approach:**
+
+- Add a `completion-candidates` command group or equivalent subcommands under `tasks.py`.
+- Provide at least: `scan`, `list`, `show`, `confirm`, `reject`, and `snooze`.
+- Keep all outputs in the stable schema envelope style used by existing primitives.
+- Ensure `confirm` accepts a candidate ID and either uses the candidate's exact canonical `matched_task_id` or requires an explicit `--task-id`.
+- Make errors structured: missing candidate, ambiguous/missing task ID, malformed ledger, candidate already terminal, apply failure, and invalid snooze date/window.
+
+**Test scenarios:**
+
+- `scan --file` returns created/existing candidate counts and candidate rows.
+- `list` shows only actionable candidates by default and can include terminal candidates with an option.
+- `show <candidate_id>` returns source, status, match metadata, and decision history.
+- `reject <candidate_id>` records a rejection and removes it from default actionable list.
+- `snooze <candidate_id> --until YYYY-MM-DD` hides it until the date/window and preserves it in full history.
+
+**Verification:**
+
+- CLI users and agents can review and decide candidates without parsing raw ledger lines.
+
+### U4. Confirm Through ID-Only Done and Record Apply Results
+
+**Goal:** Make candidate confirmation call the hardened ID-only completion kernel and record decision/apply results.
+
+**Requirements:** R4, R5, R7, R8
+
+**Dependencies:** U1, U3
+
+**Files:**
+
+- Modify: `scripts/completion_candidates.py`
+- Modify: `scripts/tasks.py`
+- Test: `tests/test_completion_candidates.py`
+- Test: `tests/test_task_transitions.py`
+
+**Approach:**
+
+- On confirm, validate candidate status and canonical task ID before mutation.
+- Call `complete_by_id(task_id, source="completion_candidate")`.
+- On success, append candidate confirmation metadata that links candidate ID to the resulting transition event ID.
+- On failure, append `candidate_apply_failed` with the structured error and leave the candidate retryable.
+- Do not mark a candidate confirmed before the ID-only completion succeeds unless the event clearly records that application failed.
+
+**Test scenarios:**
+
+- Confirming an exact-ID candidate removes/rolls forward the active task and writes both candidate and state-transition events.
+- Confirming a title-only/fuzzy candidate without canonical ID fails with no board write.
+- Confirming with explicit `--task-id` succeeds only when that canonical ID resolves exactly once.
+- If `complete_by_id()` fails, candidate status becomes `apply_failed`, active board remains restored, and retry is possible.
+- Confirming an already confirmed/rejected/expired candidate returns a structured error and writes no duplicate state transition.
+
+**Verification:**
+
+- Candidate confirmation cannot create a second mutation path around `complete_by_id()`.
+
+### U5. Documentation, Schema, and Guardrails
+
+**Goal:** Document the evidence inbox contract and keep future agents from treating suggestions as completions.
+
+**Requirements:** R5, R9, R10
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `references/commands.md`
+- Modify: `references/task-primitives-schema-v1.md`
+- Add or modify: `docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md`
+
+**Approach:**
+
+- Add examples that show scan/list/confirm/reject/snooze behavior without implying auto-completion.
+- Document that Gmail/calendar/session/Lobster ingestion is deliberately deferred.
+- Document that fuzzy/title/fallback suggestions require explicit canonical ID confirmation.
+- Keep legacy EOD `--apply` clearly separate from canonical completion candidates.
+
+**Test scenarios:**
+
+- Help text and docs do not advertise auto-confirm or fuzzy completion.
+- Schema docs show candidate states and structured error payloads.
+- Public hygiene checks pass.
+
+**Verification:**
+
+- A user or agent reading docs/help can identify the safe path: scan evidence, review candidate, confirm by canonical task ID.
+
+---
+
+## System-Wide Impact
+
+- **User trust:** Done evidence becomes reviewable and durable rather than silently disappearing into one-off JSON output.
+- **Agent behavior:** Agents get a safe decision queue instead of using fuzzy/title output as a mutation instruction.
+- **Workflow safety:** 108C creates the future integration target for EOD, Telegram, Gmail, calendar, session logs, and Lobster cron without wiring those sources yet.
+- **Auditability:** Candidate decisions become ledger events linked to task state transitions when confirmation succeeds.
+- **Compatibility:** Existing `ingest-daily-log` can remain as a read-only primitive while the new inbox provides durable candidate state.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Candidate ledger projection becomes a second task system | Keep candidates separate from task state; only `complete_by_id()` mutates active tasks. |
+| Fuzzy/title suggestions are mistaken for permission to complete | Use `suggested_match` language and block confirm without canonical task ID. |
+| Repeated scans flood the inbox | Stable candidate IDs and candidate-state projection dedupe by source evidence. |
+| Apply failure creates confusing "confirmed but active" states | Record `apply_failed` separately and keep candidate retryable. |
+| Ledger malformed lines corrupt candidate projection | Use strict/reporting ledger reads for candidate commands and return degraded/error payloads. |
+| CLI surface grows too broad | Limit first slice to scan/list/show/confirm/reject/snooze and daily/EOD-style evidence only. |
+
+---
+
+## Deferred Implementation Notes
+
+- Final CLI spelling can be `completion-candidates` or a shorter alias if local command conventions make one clearly better.
+- Exact candidate event names may vary, but they must remain distinct from `state_transition` events.
+- Candidate expiry policy can be manual or simple time-window based in this slice; do not add scheduler/cron expiry yet.
+- Daily-note scan line-number fidelity may depend on existing extractor detail. If source line numbers are not available, use a stable source pointer based on date/path plus normalized summary and timestamp where available.
+
+---
+
+## Verification Strategy
+
+- Run focused candidate tests for scan/list/show/confirm/reject/snooze and apply failure.
+- Run existing identity, transition, ledger, primitive, EOD, and weekly tests to prove the new inbox does not regress the foundation.
+- Run CLI help checks for `tasks.py done`, `tasks.py ingest-daily-log`, and new completion-candidate commands.
+- Run public hygiene and markdown lint on changed docs.
+- Manually inspect sample JSON for one exact-ID candidate, one fuzzy suggestion, one fallback-only candidate, one rejected candidate, and one apply-failed candidate.
+
+---
+
+## Sources & References
+
+- `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- `docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md`
+- `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`
+- `docs/ARCHITECTURE.md`
+- Oracle progress review pasted in the planning conversation on 2026-05-21

--- a/references/commands.md
+++ b/references/commands.md
@@ -84,6 +84,27 @@ All primitives return JSON with a stable envelope:
 
 Detailed shape: `references/task-primitives-schema-v1.md`.
 
+### Completion evidence inbox
+
+```bash
+python3 scripts/tasks.py completion-candidates scan --file /tmp/done-log.md
+cat /tmp/done-log.md | python3 scripts/tasks.py completion-candidates scan
+python3 scripts/tasks.py completion-candidates scan --date 2026-05-21
+python3 scripts/tasks.py completion-candidates list
+python3 scripts/tasks.py completion-candidates show cand_example
+python3 scripts/tasks.py completion-candidates confirm cand_example --task-id tsk_example
+python3 scripts/tasks.py completion-candidates reject cand_example \
+  --reason "not actually done"
+python3 scripts/tasks.py completion-candidates duplicate cand_example --of cand_original
+python3 scripts/tasks.py completion-candidates snooze cand_example --until 2026-05-28
+```
+
+Scanning creates durable candidate events in the ledger, but never mutates the
+task board or completion log. Confirmation is the only task-changing candidate
+action, and it completes through the same canonical-ID `done` path. Exact
+`task_id::` evidence can confirm directly; title, fuzzy, and fallback-only
+suggestions require `--task-id`.
+
 ## Wrapper shortcuts
 
 ```bash

--- a/references/task-primitives-schema-v1.md
+++ b/references/task-primitives-schema-v1.md
@@ -62,11 +62,13 @@ canonical IDs from `task_id::` or migrated legacy `id::` metadata.
 ## `ingest-daily-log`
 
 Pipeline order is deterministic:
+
 1. exact id/link match
 2. normalized title exact match
 3. fuzzy match with threshold bands
 
 Threshold decision bands:
+
 - `score >= evidence_link threshold` -> `evidence-link`
 - `review_threshold <= score < evidence_link threshold` -> `needs-review`
 - `score < review_threshold` -> `no-match`
@@ -141,3 +143,70 @@ Optional helper command. It must not hard-fail if calendar/task sources are unav
   }
 }
 ```
+
+## `completion-candidates`
+
+The completion evidence inbox stores candidate lifecycle events in the JSONL
+ledger. Candidate projection uses strict ledger reads; malformed JSONL returns a
+structured `malformed-ledger` error instead of producing a partial inbox.
+
+Scanning commands accept stdin, `--file PATH`, or `--date YYYY-MM-DD` with
+`TASK_TRACKER_DAILY_NOTES_DIR` / `--notes-dir`. Scan only appends
+`candidate_seen` events for new evidence. It does not write the board, daily
+completion log, or task state. `no-match` lines remain report-only and are not
+persisted as candidates.
+
+```json
+{
+  "schema_version": "v1",
+  "command": "completion-candidates scan",
+  "created": [
+    {
+      "candidate_id": "cand_abc123",
+      "status": "new",
+      "source": {
+        "type": "file|stdin|daily_note",
+        "path": "/tmp/done-log.md",
+        "date": "2026-05-21",
+        "line_number": 4
+      },
+      "raw_summary": "- [x] Ship alpha milestone task_id::tsk_ship",
+      "summary": "Ship alpha milestone task_id::tsk_ship",
+      "normalized_summary": "ship alpha milestone task id tsk_ship",
+      "matched_task_id": "tsk_ship",
+      "suggested_match": {
+        "task_id": "tsk_ship",
+        "title": "Ship alpha milestone",
+        "fallback_only": false
+      },
+      "match_metadata": {
+        "matched_task_id": "tsk_ship",
+        "score": 1.0,
+        "decision": "evidence-link",
+        "match_type": "exact-id-or-link"
+      }
+    }
+  ],
+  "existing": [],
+  "totals": {
+    "parsed_evidence": 1,
+    "created": 1,
+    "existing": 0
+  }
+}
+```
+
+Decision commands use the same envelope with command names such as
+`completion-candidates confirm`, `completion-candidates reject`, and
+`completion-candidates duplicate`. Candidate statuses are `new`, `shown`,
+`confirmed`, `rejected`, `duplicate`, `snoozed`, `expired`, and `apply_failed`.
+
+Confirmation rules:
+
+- exact `task_id::` or exact link evidence may confirm without `--task-id`
+- title, fuzzy, issue-number fallback, and fallback-only matches require
+  explicit `--task-id`
+- confirmation calls the canonical ID-only completion path and writes a
+  `candidate_confirmed` event only after task completion succeeds
+- failed application writes `candidate_apply_failed` and leaves the candidate
+  retryable

--- a/scripts/completion_candidates.py
+++ b/scripts/completion_candidates.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from task_ledger import append_event, ledger_path, new_event, read_events
 from task_transitions import complete_by_id
+from utils import get_tasks_file
 
 ACTIVE_STATUSES = {"new", "shown", "snoozed", "apply_failed"}
 TERMINAL_STATUSES = {"confirmed", "rejected", "duplicate", "expired"}
@@ -24,6 +25,11 @@ DECISION_EVENTS = {
     "candidate_expired",
     "candidate_apply_failed",
 }
+
+
+def _candidate_ledger_path(personal: bool = False) -> Path:
+    tasks_file, _ = get_tasks_file(personal)
+    return ledger_path(tasks_file)
 
 
 def _normalize_summary(value: str) -> str:
@@ -53,8 +59,13 @@ def _candidate_from_seen(event: dict[str, Any]) -> dict[str, Any]:
     return candidate
 
 
-def project_candidates(path: Path | None = None, *, include_terminal: bool = False) -> list[dict[str, Any]]:
-    events = read_events(path or ledger_path(), strict=True)
+def project_candidates(
+    path: Path | None = None,
+    *,
+    include_terminal: bool = False,
+    personal: bool = False,
+) -> list[dict[str, Any]]:
+    events = read_events(path or _candidate_ledger_path(personal), strict=True)
     candidates: dict[str, dict[str, Any]] = {}
 
     for event in events:
@@ -116,8 +127,13 @@ def project_candidates(path: Path | None = None, *, include_terminal: bool = Fal
     return sorted(projected, key=lambda item: item.get("candidate_id", ""))
 
 
-def get_candidate(candidate_id: str, *, include_terminal: bool = True) -> dict[str, Any] | None:
-    for candidate in project_candidates(include_terminal=include_terminal):
+def get_candidate(
+    candidate_id: str,
+    *,
+    include_terminal: bool = True,
+    personal: bool = False,
+) -> dict[str, Any] | None:
+    for candidate in project_candidates(include_terminal=include_terminal, personal=personal):
         if candidate.get("candidate_id") == candidate_id:
             return candidate
     return None
@@ -190,7 +206,10 @@ def _match_evidence_lines(content: str, source: dict[str, Any], *, personal: boo
 
 def scan_content(content: str, source: dict[str, Any], *, personal: bool = False) -> dict[str, Any]:
     candidates = _match_evidence_lines(content, source, personal=personal)
-    existing = {candidate["candidate_id"]: candidate for candidate in project_candidates(include_terminal=True)}
+    existing = {
+        candidate["candidate_id"]: candidate
+        for candidate in project_candidates(include_terminal=True, personal=personal)
+    }
     created: list[dict[str, Any]] = []
     already_seen: list[dict[str, Any]] = []
 
@@ -204,7 +223,7 @@ def scan_content(content: str, source: dict[str, Any], *, personal: bool = False
             source="completion_candidate_scan",
             metadata={"candidate": candidate},
         )
-        append_event(event)
+        append_event(event, path=_candidate_ledger_path(personal))
         created.append(candidate)
 
     return {
@@ -228,18 +247,21 @@ def scan_daily_note(notes_dir: Path, day: date, *, personal: bool = False) -> di
     return scan_content(content, source, personal=personal)
 
 
-def mark_shown(candidate_id: str) -> dict[str, Any]:
-    candidate = get_candidate(candidate_id)
+def mark_shown(candidate_id: str, *, personal: bool = False) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id, personal=personal)
     if candidate is None:
         return {"ok": False, "error": {"code": "candidate-not-found"}}
     if candidate.get("status") in TERMINAL_STATUSES:
         return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
-    append_event(new_event("candidate_shown", task_id=candidate_id, source="completion_candidate_cli"))
-    return {"ok": True, "candidate": get_candidate(candidate_id)}
+    append_event(
+        new_event("candidate_shown", task_id=candidate_id, source="completion_candidate_cli"),
+        path=_candidate_ledger_path(personal),
+    )
+    return {"ok": True, "candidate": get_candidate(candidate_id, personal=personal)}
 
 
-def reject_candidate(candidate_id: str, *, reason: str | None = None) -> dict[str, Any]:
-    candidate = get_candidate(candidate_id)
+def reject_candidate(candidate_id: str, *, reason: str | None = None, personal: bool = False) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id, personal=personal)
     if candidate is None:
         return {"ok": False, "error": {"code": "candidate-not-found"}}
     if candidate.get("status") in TERMINAL_STATUSES:
@@ -250,18 +272,21 @@ def reject_candidate(candidate_id: str, *, reason: str | None = None) -> dict[st
             task_id=candidate_id,
             source="completion_candidate_cli",
             metadata={"reason": reason},
-        )
+        ),
+        path=_candidate_ledger_path(personal),
     )
-    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True)}
+    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True, personal=personal)}
 
 
-def duplicate_candidate(candidate_id: str, *, duplicate_of: str) -> dict[str, Any]:
-    candidate = get_candidate(candidate_id)
+def duplicate_candidate(candidate_id: str, *, duplicate_of: str, personal: bool = False) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id, personal=personal)
     if candidate is None:
         return {"ok": False, "error": {"code": "candidate-not-found"}}
     if candidate.get("status") in TERMINAL_STATUSES:
         return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
-    if not get_candidate(duplicate_of, include_terminal=True):
+    if candidate_id == duplicate_of:
+        return {"ok": False, "error": {"code": "self-duplicate-blocked"}}
+    if not get_candidate(duplicate_of, include_terminal=True, personal=personal):
         return {"ok": False, "error": {"code": "duplicate-target-not-found"}}
     append_event(
         new_event(
@@ -269,17 +294,18 @@ def duplicate_candidate(candidate_id: str, *, duplicate_of: str) -> dict[str, An
             task_id=candidate_id,
             source="completion_candidate_cli",
             metadata={"duplicate_of": duplicate_of},
-        )
+        ),
+        path=_candidate_ledger_path(personal),
     )
-    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True)}
+    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True, personal=personal)}
 
 
-def snooze_candidate(candidate_id: str, *, until: str) -> dict[str, Any]:
+def snooze_candidate(candidate_id: str, *, until: str, personal: bool = False) -> dict[str, Any]:
     try:
         datetime.strptime(until, "%Y-%m-%d")
     except ValueError:
         return {"ok": False, "error": {"code": "invalid-snooze-date"}}
-    candidate = get_candidate(candidate_id)
+    candidate = get_candidate(candidate_id, personal=personal)
     if candidate is None:
         return {"ok": False, "error": {"code": "candidate-not-found"}}
     if candidate.get("status") in TERMINAL_STATUSES:
@@ -290,9 +316,10 @@ def snooze_candidate(candidate_id: str, *, until: str) -> dict[str, Any]:
             task_id=candidate_id,
             source="completion_candidate_cli",
             metadata={"until": until},
-        )
+        ),
+        path=_candidate_ledger_path(personal),
     )
-    return {"ok": True, "candidate": get_candidate(candidate_id)}
+    return {"ok": True, "candidate": get_candidate(candidate_id, personal=personal)}
 
 
 def _candidate_task_id(candidate: dict[str, Any], explicit_task_id: str | None) -> tuple[str | None, dict[str, Any] | None]:
@@ -312,7 +339,7 @@ def _candidate_task_id(candidate: dict[str, Any], explicit_task_id: str | None) 
 
 
 def confirm_candidate(candidate_id: str, *, task_id: str | None = None, personal: bool = False) -> dict[str, Any]:
-    candidate = get_candidate(candidate_id)
+    candidate = get_candidate(candidate_id, personal=personal)
     if candidate is None:
         return {"ok": False, "error": {"code": "candidate-not-found"}}
     if candidate.get("status") in TERMINAL_STATUSES:
@@ -348,8 +375,17 @@ def confirm_candidate(candidate_id: str, *, task_id: str | None = None, personal
                 task_id=candidate_id,
                 source="completion_candidate_cli",
                 metadata={"task_id": resolved_task_id, "error": result.get("error")},
-            )
+            ),
+            path=_candidate_ledger_path(personal),
         )
-        return {"ok": False, "candidate": get_candidate(candidate_id), "error": result.get("error")}
+        return {
+            "ok": False,
+            "candidate": get_candidate(candidate_id, personal=personal),
+            "error": result.get("error"),
+        }
 
-    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True), "completion": result}
+    return {
+        "ok": True,
+        "candidate": get_candidate(candidate_id, include_terminal=True, personal=personal),
+        "completion": result,
+    }

--- a/scripts/completion_candidates.py
+++ b/scripts/completion_candidates.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Completion evidence candidate inbox backed by the task ledger."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+from task_ledger import append_event, ledger_path, new_event, read_events
+from task_transitions import complete_by_id
+
+ACTIVE_STATUSES = {"new", "shown", "snoozed", "apply_failed"}
+TERMINAL_STATUSES = {"confirmed", "rejected", "duplicate", "expired"}
+DECISION_EVENTS = {
+    "candidate_seen",
+    "candidate_shown",
+    "candidate_confirmed",
+    "candidate_rejected",
+    "candidate_snoozed",
+    "candidate_duplicate",
+    "candidate_expired",
+    "candidate_apply_failed",
+}
+
+
+def _normalize_summary(value: str) -> str:
+    normalized = " ".join((value or "").casefold().split())
+    return normalized
+
+
+def candidate_id_for(source: dict[str, Any], summary: str) -> str:
+    stable = {
+        "source_type": source.get("type"),
+        "source_path": source.get("path"),
+        "source_date": source.get("date"),
+        "line_number": source.get("line_number"),
+        "timestamp": source.get("timestamp"),
+        "summary": _normalize_summary(summary),
+    }
+    material = json.dumps(stable, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return f"cand_{hashlib.sha256(material.encode('utf-8')).hexdigest()[:20]}"
+
+
+def _candidate_from_seen(event: dict[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata") or {}
+    candidate = dict(metadata.get("candidate") or {})
+    candidate.setdefault("candidate_id", event.get("task_id"))
+    candidate.setdefault("status", "new")
+    candidate.setdefault("history", [])
+    return candidate
+
+
+def project_candidates(path: Path | None = None, *, include_terminal: bool = False) -> list[dict[str, Any]]:
+    events = read_events(path or ledger_path(), strict=True)
+    candidates: dict[str, dict[str, Any]] = {}
+
+    for event in events:
+        event_type = event.get("event_type")
+        if event_type not in DECISION_EVENTS:
+            continue
+        candidate_id = event.get("task_id")
+        if not candidate_id:
+            continue
+
+        if event_type == "candidate_seen":
+            candidate = candidates.get(candidate_id) or _candidate_from_seen(event)
+            candidate.update(_candidate_from_seen(event))
+            candidates[candidate_id] = candidate
+        else:
+            candidate = candidates.setdefault(
+                candidate_id,
+                {
+                    "candidate_id": candidate_id,
+                    "status": "new",
+                    "history": [],
+                },
+            )
+
+        metadata = event.get("metadata") or {}
+        history_row = {
+            "event_id": event.get("event_id"),
+            "event_type": event_type,
+            "timestamp": event.get("timestamp"),
+            "metadata": metadata,
+        }
+        candidate.setdefault("history", []).append(history_row)
+
+        if event_type == "candidate_shown" and candidate.get("status") in ACTIVE_STATUSES:
+            candidate["status"] = "shown"
+        elif event_type == "candidate_confirmed":
+            candidate["status"] = "confirmed"
+            candidate["confirmed_task_id"] = metadata.get("task_id")
+            candidate["transition_event_id"] = metadata.get("transition_event_id")
+        elif event_type == "candidate_rejected":
+            candidate["status"] = "rejected"
+            candidate["reason"] = metadata.get("reason")
+        elif event_type == "candidate_snoozed":
+            candidate["status"] = "snoozed"
+            candidate["snoozed_until"] = metadata.get("until")
+        elif event_type == "candidate_duplicate":
+            candidate["status"] = "duplicate"
+            candidate["duplicate_of"] = metadata.get("duplicate_of")
+        elif event_type == "candidate_expired":
+            candidate["status"] = "expired"
+            candidate["reason"] = metadata.get("reason")
+        elif event_type == "candidate_apply_failed":
+            candidate["status"] = "apply_failed"
+            candidate["last_error"] = metadata.get("error")
+
+    projected = list(candidates.values())
+    if not include_terminal:
+        projected = [candidate for candidate in projected if candidate.get("status") not in TERMINAL_STATUSES]
+    return sorted(projected, key=lambda item: item.get("candidate_id", ""))
+
+
+def get_candidate(candidate_id: str, *, include_terminal: bool = True) -> dict[str, Any] | None:
+    for candidate in project_candidates(include_terminal=include_terminal):
+        if candidate.get("candidate_id") == candidate_id:
+            return candidate
+    return None
+
+
+def _build_candidate_from_match(item: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    source_pointer = dict(source)
+    if item.get("line_number") is not None:
+        source_pointer["line_number"] = item.get("line_number")
+    summary = item.get("parsed_title") or item.get("raw_line") or ""
+    candidate_id = candidate_id_for(source_pointer, summary)
+    match_metadata = dict(item.get("match_metadata") or {})
+    canonical_task = item.get("canonical_task")
+    return {
+        "candidate_id": candidate_id,
+        "status": "new",
+        "source": source_pointer,
+        "raw_summary": item.get("raw_line"),
+        "summary": summary,
+        "normalized_summary": item.get("normalized_title") or _normalize_summary(summary),
+        "suggested_match": canonical_task,
+        "match_metadata": match_metadata,
+        "matched_task_id": match_metadata.get("matched_task_id"),
+    }
+
+
+def _source_from_file(path: Path) -> tuple[str, dict[str, Any]]:
+    content = path.read_text(encoding="utf-8")
+    return content, {"type": "file", "path": str(path)}
+
+
+def _source_from_daily_note(notes_dir: Path, day: date) -> tuple[str, dict[str, Any]]:
+    path = notes_dir / f"{day.isoformat()}.md"
+    content = path.read_text(encoding="utf-8")
+    return content, {"type": "daily_note", "path": str(path), "date": day.isoformat()}
+
+
+def _match_evidence_lines(content: str, source: dict[str, Any], *, personal: bool = False) -> list[dict[str, Any]]:
+    from tasks import (
+        FUZZY_EVIDENCE_LINK_THRESHOLD,
+        FUZZY_REVIEW_THRESHOLD,
+        _build_task_catalog,
+        _extract_done_lines,
+        _ingest_match_line,
+        _safe_load_task_records,
+    )
+
+    parsed = _extract_done_lines(content)
+    records = _safe_load_task_records(personal)
+    catalog = _build_task_catalog(records)
+    matched = []
+    for line in parsed:
+        match = _ingest_match_line(
+            line,
+            catalog,
+            auto_threshold=FUZZY_EVIDENCE_LINK_THRESHOLD,
+            review_threshold=FUZZY_REVIEW_THRESHOLD,
+        )
+        match["line_number"] = line.get("line_number")
+        if (match.get("match_metadata") or {}).get("decision") == "no-match":
+            continue
+        matched.append(match)
+    candidates = []
+    for index, item in enumerate(matched, start=1):
+        candidate_source = dict(source)
+        candidate_source.setdefault("line_number", index)
+        candidates.append(_build_candidate_from_match(item, candidate_source))
+    return candidates
+
+
+def scan_content(content: str, source: dict[str, Any], *, personal: bool = False) -> dict[str, Any]:
+    candidates = _match_evidence_lines(content, source, personal=personal)
+    existing = {candidate["candidate_id"]: candidate for candidate in project_candidates(include_terminal=True)}
+    created: list[dict[str, Any]] = []
+    already_seen: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        if candidate["candidate_id"] in existing:
+            already_seen.append(existing[candidate["candidate_id"]])
+            continue
+        event = new_event(
+            "candidate_seen",
+            task_id=candidate["candidate_id"],
+            source="completion_candidate_scan",
+            metadata={"candidate": candidate},
+        )
+        append_event(event)
+        created.append(candidate)
+
+    return {
+        "created": created,
+        "existing": already_seen,
+        "totals": {
+            "parsed_evidence": len(candidates),
+            "created": len(created),
+            "existing": len(already_seen),
+        },
+    }
+
+
+def scan_file(path: Path, *, personal: bool = False) -> dict[str, Any]:
+    content, source = _source_from_file(path)
+    return scan_content(content, source, personal=personal)
+
+
+def scan_daily_note(notes_dir: Path, day: date, *, personal: bool = False) -> dict[str, Any]:
+    content, source = _source_from_daily_note(notes_dir, day)
+    return scan_content(content, source, personal=personal)
+
+
+def mark_shown(candidate_id: str) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id)
+    if candidate is None:
+        return {"ok": False, "error": {"code": "candidate-not-found"}}
+    if candidate.get("status") in TERMINAL_STATUSES:
+        return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
+    append_event(new_event("candidate_shown", task_id=candidate_id, source="completion_candidate_cli"))
+    return {"ok": True, "candidate": get_candidate(candidate_id)}
+
+
+def reject_candidate(candidate_id: str, *, reason: str | None = None) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id)
+    if candidate is None:
+        return {"ok": False, "error": {"code": "candidate-not-found"}}
+    if candidate.get("status") in TERMINAL_STATUSES:
+        return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
+    append_event(
+        new_event(
+            "candidate_rejected",
+            task_id=candidate_id,
+            source="completion_candidate_cli",
+            metadata={"reason": reason},
+        )
+    )
+    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True)}
+
+
+def duplicate_candidate(candidate_id: str, *, duplicate_of: str) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id)
+    if candidate is None:
+        return {"ok": False, "error": {"code": "candidate-not-found"}}
+    if candidate.get("status") in TERMINAL_STATUSES:
+        return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
+    if not get_candidate(duplicate_of, include_terminal=True):
+        return {"ok": False, "error": {"code": "duplicate-target-not-found"}}
+    append_event(
+        new_event(
+            "candidate_duplicate",
+            task_id=candidate_id,
+            source="completion_candidate_cli",
+            metadata={"duplicate_of": duplicate_of},
+        )
+    )
+    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True)}
+
+
+def snooze_candidate(candidate_id: str, *, until: str) -> dict[str, Any]:
+    try:
+        datetime.strptime(until, "%Y-%m-%d")
+    except ValueError:
+        return {"ok": False, "error": {"code": "invalid-snooze-date"}}
+    candidate = get_candidate(candidate_id)
+    if candidate is None:
+        return {"ok": False, "error": {"code": "candidate-not-found"}}
+    if candidate.get("status") in TERMINAL_STATUSES:
+        return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
+    append_event(
+        new_event(
+            "candidate_snoozed",
+            task_id=candidate_id,
+            source="completion_candidate_cli",
+            metadata={"until": until},
+        )
+    )
+    return {"ok": True, "candidate": get_candidate(candidate_id)}
+
+
+def _candidate_task_id(candidate: dict[str, Any], explicit_task_id: str | None) -> tuple[str | None, dict[str, Any] | None]:
+    if explicit_task_id:
+        return explicit_task_id, None
+    match_metadata = candidate.get("match_metadata") or {}
+    match_type = match_metadata.get("match_type")
+    if match_type != "exact-id-or-link":
+        return None, {
+            "code": "explicit-task-id-required",
+            "message": "Only exact canonical ID/link evidence can be confirmed without --task-id.",
+        }
+    task_id = candidate.get("matched_task_id")
+    if not task_id:
+        return None, {"code": "canonical-task-id-missing"}
+    return task_id, None
+
+
+def confirm_candidate(candidate_id: str, *, task_id: str | None = None, personal: bool = False) -> dict[str, Any]:
+    candidate = get_candidate(candidate_id)
+    if candidate is None:
+        return {"ok": False, "error": {"code": "candidate-not-found"}}
+    if candidate.get("status") in TERMINAL_STATUSES:
+        return {"ok": False, "error": {"code": "candidate-terminal", "status": candidate.get("status")}}
+
+    resolved_task_id, error = _candidate_task_id(candidate, task_id)
+    if error:
+        return {"ok": False, "error": error}
+
+    def confirmed_events(transition_event: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            new_event(
+                "candidate_confirmed",
+                task_id=candidate_id,
+                source="completion_candidate_cli",
+                metadata={
+                    "task_id": resolved_task_id,
+                    "transition_event_id": transition_event.get("event_id"),
+                },
+            )
+        ]
+
+    result = complete_by_id(
+        resolved_task_id,
+        personal=personal,
+        source="completion_candidate",
+        extra_events_factory=confirmed_events,
+    )
+    if not result.get("ok"):
+        append_event(
+            new_event(
+                "candidate_apply_failed",
+                task_id=candidate_id,
+                source="completion_candidate_cli",
+                metadata={"task_id": resolved_task_id, "error": result.get("error")},
+            )
+        )
+        return {"ok": False, "candidate": get_candidate(candidate_id), "error": result.get("error")}
+
+    return {"ok": True, "candidate": get_candidate(candidate_id, include_terminal=True), "completion": result}

--- a/scripts/task_transitions.py
+++ b/scripts/task_transitions.py
@@ -8,6 +8,7 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 from log_done import log_task_completed
 from task_lines import remove_task_line, replace_task_line
@@ -118,7 +119,12 @@ def _resolve_by_id(task_id: str, personal: bool = False):
     return tasks_file, content, matches[0], None
 
 
-def complete_by_id(task_id: str, personal: bool = False, source: str = "user_command") -> dict:
+def complete_by_id(
+    task_id: str,
+    personal: bool = False,
+    source: str = "user_command",
+    extra_events_factory: Callable[[dict], list[dict]] | None = None,
+) -> dict:
     tasks_file, content, record, error = _resolve_by_id(task_id, personal)
     if error:
         return error
@@ -135,6 +141,7 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
         reason="explicit-done-by-canonical-id",
         metadata={"title": record.title, "line_number": record.line_number},
     )
+    extra_events = extra_events_factory(event) if extra_events_factory else []
 
     due_value = _extract_due_date(record.raw_line)
     recur_value = _extract_recur_value(record.raw_line) or ""
@@ -205,6 +212,8 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
         tasks_file.write_text(new_content, encoding="utf-8")
         write_stage = "ledger-append"
         append_event(event, path=ledger_path(tasks_file))
+        for extra_event in extra_events:
+            append_event(extra_event, path=ledger_path(tasks_file))
     except OSError as exc:
         restore_error = _restore_after_failure(snapshots)
         code = "ledger-append-failed" if write_stage == "ledger-append" else "task-state-write-failed"
@@ -218,7 +227,13 @@ def complete_by_id(task_id: str, personal: bool = False, source: str = "user_com
             "ok": False,
             "error": error,
         }
-    return {"ok": True, "task_id": task_id, "title": record.title, "event": event}
+    return {
+        "ok": True,
+        "task_id": task_id,
+        "title": record.title,
+        "event": event,
+        "extra_events": extra_events,
+    }
 
 
 def block_unsafe_query(query: str) -> dict:

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -804,7 +804,7 @@ def _parse_range_inputs(week: str | None, start_raw: str | None, end_raw: str | 
 
 def _extract_done_lines(content: str) -> list[dict]:
     parsed: list[dict] = []
-    for raw in content.splitlines():
+    for line_number, raw in enumerate(content.splitlines(), start=1):
         line = raw.strip()
         if not line:
             continue
@@ -832,6 +832,7 @@ def _extract_done_lines(content: str) -> list[dict]:
         parsed.append(
             {
                 "raw_line": raw.rstrip("\n"),
+                "line_number": line_number,
                 "title": cleaned,
                 "normalized_title": _normalize_title(cleaned),
                 "exact_identifiers": identifiers["exact"],
@@ -1228,6 +1229,160 @@ def cmd_ingest_daily_log(args):
     print(json.dumps(payload, indent=2))
 
 
+def _candidate_payload(command: str, **fields) -> dict:
+    payload = _new_schema(command)
+    payload.update(fields)
+    return payload
+
+
+def _print_candidate_result(result: dict, *, command: str, exit_on_error: bool = True) -> None:
+    if "schema_version" not in result:
+        result = _candidate_payload(command, **result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if exit_on_error and result.get("ok") is False:
+        sys.exit(2)
+
+
+def cmd_completion_candidates(args):
+    from completion_candidates import (
+        confirm_candidate,
+        duplicate_candidate,
+        get_candidate,
+        mark_shown,
+        project_candidates,
+        reject_candidate,
+        scan_content,
+        scan_daily_note,
+        scan_file,
+        snooze_candidate,
+    )
+    from task_ledger import MalformedLedgerError
+
+    try:
+        if args.candidate_command == "scan":
+            if args.file:
+                result = scan_file(Path(args.file), personal=args.personal)
+                _print_candidate_result(result, command="completion-candidates scan", exit_on_error=False)
+                return
+            if args.date:
+                notes_dir_raw = args.notes_dir or os.getenv("TASK_TRACKER_DAILY_NOTES_DIR")
+                if not notes_dir_raw:
+                    _print_candidate_result(
+                        {"ok": False, "error": {"code": "daily-notes-dir-required"}},
+                        command="completion-candidates scan",
+                    )
+                    return
+                notes_dir = Path(notes_dir_raw).expanduser()
+                day = datetime.strptime(args.date, "%Y-%m-%d").date()
+                result = scan_daily_note(notes_dir, day, personal=args.personal)
+                _print_candidate_result(
+                    result,
+                    command="completion-candidates scan",
+                    exit_on_error=False,
+                )
+                return
+            content = sys.stdin.read()
+            result = scan_content(content, {"type": "stdin"}, personal=args.personal)
+            _print_candidate_result(
+                result,
+                command="completion-candidates scan",
+                exit_on_error=False,
+            )
+            return
+
+        if args.candidate_command == "list":
+            candidates = project_candidates(include_terminal=args.all)
+            if not args.all:
+                today = date.today().isoformat()
+                candidates = [
+                    candidate for candidate in candidates
+                    if candidate.get("status") != "snoozed"
+                    or (candidate.get("snoozed_until") or "") <= today
+                ]
+            if args.mark_shown:
+                for candidate in candidates:
+                    if candidate.get("status") == "new":
+                        mark_shown(candidate["candidate_id"])
+                candidates = project_candidates(include_terminal=args.all)
+            _print_candidate_result(
+                {"candidates": candidates, "total": len(candidates)},
+                command="completion-candidates list",
+                exit_on_error=False,
+            )
+            return
+
+        if args.candidate_command == "show":
+            candidate = get_candidate(args.candidate_id, include_terminal=True)
+            if candidate is None:
+                _print_candidate_result(
+                    {"ok": False, "error": {"code": "candidate-not-found"}},
+                    command="completion-candidates show",
+                )
+                return
+            if args.mark_shown and candidate.get("status") == "new":
+                result = mark_shown(args.candidate_id)
+                candidate = result.get("candidate")
+            _print_candidate_result(
+                {"candidate": candidate},
+                command="completion-candidates show",
+                exit_on_error=False,
+            )
+            return
+
+        if args.candidate_command == "reject":
+            result = reject_candidate(args.candidate_id, reason=args.reason)
+            _print_candidate_result(result, command="completion-candidates reject")
+            return
+
+        if args.candidate_command == "snooze":
+            result = snooze_candidate(args.candidate_id, until=args.until)
+            _print_candidate_result(result, command="completion-candidates snooze")
+            return
+
+        if args.candidate_command == "duplicate":
+            result = duplicate_candidate(args.candidate_id, duplicate_of=args.duplicate_of)
+            _print_candidate_result(result, command="completion-candidates duplicate")
+            return
+
+        if args.candidate_command == "confirm":
+            result = confirm_candidate(
+                args.candidate_id,
+                task_id=args.task_id,
+                personal=args.personal,
+            )
+            _print_candidate_result(result, command="completion-candidates confirm")
+            return
+    except MalformedLedgerError as exc:
+        _print_candidate_result(
+            {
+                "ok": False,
+                "error": {
+                    "code": "malformed-ledger",
+                    "malformed": [
+                        {
+                            "path": item.path,
+                            "line_number": item.line_number,
+                            "message": item.message,
+                            "raw_line": item.raw_line,
+                        }
+                        for item in exc.malformed
+                    ],
+                },
+            },
+            command=f"completion-candidates {args.candidate_command}",
+        )
+    except OSError as exc:
+        _print_candidate_result(
+            {"ok": False, "error": {"code": "io-error", "message": str(exc)}},
+            command=f"completion-candidates {args.candidate_command}",
+        )
+    except ValueError as exc:
+        _print_candidate_result(
+            {"ok": False, "error": {"code": "invalid-input", "message": str(exc)}},
+            command=f"completion-candidates {args.candidate_command}",
+        )
+
+
 def cmd_calendar_sync_primitive(args):
     payload = _new_schema("calendar-sync")
     warnings: list[str] = []
@@ -1437,6 +1592,92 @@ def main():
         help='Fuzzy score threshold for needs-review',
     )
     ingest_daily_log_parser.set_defaults(func=cmd_ingest_daily_log)
+
+    candidates_parser = subparsers.add_parser(
+        'completion-candidates',
+        help='Manage durable completion evidence candidates',
+    )
+    candidates_sub = candidates_parser.add_subparsers(
+        dest='candidate_command',
+        required=True,
+    )
+
+    candidates_scan = candidates_sub.add_parser(
+        'scan',
+        help='Scan done evidence into the candidate inbox',
+    )
+    candidates_scan.add_argument('--file', help='Input log file; default is stdin')
+    candidates_scan.add_argument('--date', help='Daily note date to scan (YYYY-MM-DD)')
+    candidates_scan.add_argument(
+        '--notes-dir',
+        help='Daily notes directory; defaults to TASK_TRACKER_DAILY_NOTES_DIR',
+    )
+    candidates_scan.set_defaults(func=cmd_completion_candidates)
+
+    candidates_list = candidates_sub.add_parser(
+        'list',
+        help='List active completion candidates',
+    )
+    candidates_list.add_argument(
+        '--all',
+        action='store_true',
+        help='Include terminal and future-snoozed candidates',
+    )
+    candidates_list.add_argument(
+        '--mark-shown',
+        action='store_true',
+        help='Record shown events for new listed candidates',
+    )
+    candidates_list.set_defaults(func=cmd_completion_candidates)
+
+    candidates_show = candidates_sub.add_parser(
+        'show',
+        help='Show one completion candidate and its history',
+    )
+    candidates_show.add_argument('candidate_id', help='Candidate ID')
+    candidates_show.add_argument(
+        '--mark-shown',
+        action='store_true',
+        help='Record a shown event for a new candidate',
+    )
+    candidates_show.set_defaults(func=cmd_completion_candidates)
+
+    candidates_confirm = candidates_sub.add_parser(
+        'confirm',
+        help='Confirm a candidate through ID-only completion',
+    )
+    candidates_confirm.add_argument('candidate_id', help='Candidate ID')
+    candidates_confirm.add_argument('--task-id', help='Canonical task_id to complete')
+    candidates_confirm.set_defaults(func=cmd_completion_candidates)
+
+    candidates_reject = candidates_sub.add_parser(
+        'reject',
+        help='Reject a completion candidate',
+    )
+    candidates_reject.add_argument('candidate_id', help='Candidate ID')
+    candidates_reject.add_argument('--reason', help='Optional rejection reason')
+    candidates_reject.set_defaults(func=cmd_completion_candidates)
+
+    candidates_duplicate = candidates_sub.add_parser(
+        'duplicate',
+        help='Mark a candidate as a duplicate of another candidate',
+    )
+    candidates_duplicate.add_argument('candidate_id', help='Candidate ID')
+    candidates_duplicate.add_argument(
+        '--of',
+        dest='duplicate_of',
+        required=True,
+        help='Canonical candidate ID',
+    )
+    candidates_duplicate.set_defaults(func=cmd_completion_candidates)
+
+    candidates_snooze = candidates_sub.add_parser(
+        'snooze',
+        help='Hide a candidate until a future date',
+    )
+    candidates_snooze.add_argument('candidate_id', help='Candidate ID')
+    candidates_snooze.add_argument('--until', required=True, help='Snooze-until date (YYYY-MM-DD)')
+    candidates_snooze.set_defaults(func=cmd_completion_candidates)
 
     calendar_sync_parser = subparsers.add_parser(
         'calendar-sync',

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -1243,6 +1243,17 @@ def _print_candidate_result(result: dict, *, command: str, exit_on_error: bool =
         sys.exit(2)
 
 
+def _visible_completion_candidates(candidates: list[dict], *, include_all: bool = False) -> list[dict]:
+    if include_all:
+        return candidates
+    today = date.today().isoformat()
+    return [
+        candidate for candidate in candidates
+        if candidate.get("status") != "snoozed"
+        or (candidate.get("snoozed_until") or "") <= today
+    ]
+
+
 def cmd_completion_candidates(args):
     from completion_candidates import (
         confirm_candidate,
@@ -1260,6 +1271,18 @@ def cmd_completion_candidates(args):
 
     try:
         if args.candidate_command == "scan":
+            if args.file and args.date:
+                _print_candidate_result(
+                    {
+                        "ok": False,
+                        "error": {
+                            "code": "conflicting-scan-sources",
+                            "message": "Use either --file or --date, not both.",
+                        },
+                    },
+                    command="completion-candidates scan",
+                )
+                return
             if args.file:
                 result = scan_file(Path(args.file), personal=args.personal)
                 _print_candidate_result(result, command="completion-candidates scan", exit_on_error=False)
@@ -1291,19 +1314,18 @@ def cmd_completion_candidates(args):
             return
 
         if args.candidate_command == "list":
-            candidates = project_candidates(include_terminal=args.all)
-            if not args.all:
-                today = date.today().isoformat()
-                candidates = [
-                    candidate for candidate in candidates
-                    if candidate.get("status") != "snoozed"
-                    or (candidate.get("snoozed_until") or "") <= today
-                ]
+            candidates = _visible_completion_candidates(
+                project_candidates(include_terminal=args.all, personal=args.personal),
+                include_all=args.all,
+            )
             if args.mark_shown:
                 for candidate in candidates:
                     if candidate.get("status") == "new":
-                        mark_shown(candidate["candidate_id"])
-                candidates = project_candidates(include_terminal=args.all)
+                        mark_shown(candidate["candidate_id"], personal=args.personal)
+                candidates = _visible_completion_candidates(
+                    project_candidates(include_terminal=args.all, personal=args.personal),
+                    include_all=args.all,
+                )
             _print_candidate_result(
                 {"candidates": candidates, "total": len(candidates)},
                 command="completion-candidates list",
@@ -1312,7 +1334,7 @@ def cmd_completion_candidates(args):
             return
 
         if args.candidate_command == "show":
-            candidate = get_candidate(args.candidate_id, include_terminal=True)
+            candidate = get_candidate(args.candidate_id, include_terminal=True, personal=args.personal)
             if candidate is None:
                 _print_candidate_result(
                     {"ok": False, "error": {"code": "candidate-not-found"}},
@@ -1320,7 +1342,7 @@ def cmd_completion_candidates(args):
                 )
                 return
             if args.mark_shown and candidate.get("status") == "new":
-                result = mark_shown(args.candidate_id)
+                result = mark_shown(args.candidate_id, personal=args.personal)
                 candidate = result.get("candidate")
             _print_candidate_result(
                 {"candidate": candidate},
@@ -1330,17 +1352,25 @@ def cmd_completion_candidates(args):
             return
 
         if args.candidate_command == "reject":
-            result = reject_candidate(args.candidate_id, reason=args.reason)
+            result = reject_candidate(
+                args.candidate_id,
+                reason=args.reason,
+                personal=args.personal,
+            )
             _print_candidate_result(result, command="completion-candidates reject")
             return
 
         if args.candidate_command == "snooze":
-            result = snooze_candidate(args.candidate_id, until=args.until)
+            result = snooze_candidate(args.candidate_id, until=args.until, personal=args.personal)
             _print_candidate_result(result, command="completion-candidates snooze")
             return
 
         if args.candidate_command == "duplicate":
-            result = duplicate_candidate(args.candidate_id, duplicate_of=args.duplicate_of)
+            result = duplicate_candidate(
+                args.candidate_id,
+                duplicate_of=args.duplicate_of,
+                personal=args.personal,
+            )
             _print_candidate_result(result, command="completion-candidates duplicate")
             return
 

--- a/tests/test_completion_candidates.py
+++ b/tests/test_completion_candidates.py
@@ -1,0 +1,288 @@
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import completion_candidates
+import task_records
+import task_transitions
+
+
+def _write_work_file(tmp_path, content=None):
+    work = tmp_path / "Work Tasks.md"
+    work.write_text(
+        content
+        or """# Work
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+- [ ] **Fix login timeout** task_id::tsk_login area:: Platform
+- [ ] **Write onboarding docs** task_id::tsk_docs area:: Docs
+"""
+    )
+    return work
+
+
+def _env(tmp_path, work):
+    env = os.environ.copy()
+    env["TASK_TRACKER_WORK_FILE"] = str(work)
+    env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(tmp_path / "daily")
+    env["TASK_TRACKER_DONE_LOG_DIR"] = str(tmp_path / "daily")
+    env["TASK_TRACKER_LEDGER_FILE"] = str(tmp_path / "events.jsonl")
+    env["STANDUP_CALENDARS"] = "{}"
+    return env
+
+
+def _run(args, env, *, input_text=None):
+    return subprocess.run(
+        ["python3", "scripts/tasks.py", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _payload(proc):
+    assert "Traceback" not in proc.stdout
+    assert "Traceback" not in proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _scan_file(tmp_path, env, text):
+    source = tmp_path / "done.md"
+    source.write_text(text)
+    proc = _run(["completion-candidates", "scan", "--file", str(source)], env)
+    assert proc.returncode == 0, proc.stderr
+    return _payload(proc)
+
+
+def _candidate_id(payload, index=0):
+    return payload["created"][index]["candidate_id"]
+
+
+def _ledger_events(tmp_path):
+    ledger = tmp_path / "events.jsonl"
+    if not ledger.exists():
+        return []
+    return [json.loads(line) for line in ledger.read_text().splitlines() if line.strip()]
+
+
+def test_scan_dedupes_same_evidence_without_task_mutation(tmp_path):
+    work = _write_work_file(tmp_path)
+    original = work.read_text()
+    env = _env(tmp_path, work)
+
+    first = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+    second = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+
+    assert first["totals"]["created"] == 1
+    assert second["totals"]["created"] == 0
+    assert second["totals"]["existing"] == 1
+    assert work.read_text() == original
+    assert [event["event_type"] for event in _ledger_events(tmp_path)] == ["candidate_seen"]
+
+
+def test_scan_preserves_original_source_line_number(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+
+    payload = _scan_file(
+        tmp_path,
+        env,
+        "# Done today\n\n- Ship alpha milestone task_id::tsk_ship\n",
+    )
+
+    assert payload["created"][0]["source"]["line_number"] == 3
+
+
+def test_title_candidate_requires_explicit_task_id_before_confirmation(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone\n")
+    candidate_id = _candidate_id(scan)
+
+    blocked = _run(["completion-candidates", "confirm", candidate_id], env)
+    blocked_payload = _payload(blocked)
+
+    assert blocked.returncode == 2
+    assert blocked_payload["error"]["code"] == "explicit-task-id-required"
+    assert "Ship alpha milestone" in work.read_text()
+
+    confirmed = _run(["completion-candidates", "confirm", candidate_id, "--task-id", "tsk_ship"], env)
+    confirmed_payload = _payload(confirmed)
+
+    assert confirmed.returncode == 0
+    assert confirmed_payload["ok"] is True
+    assert "Ship alpha milestone" not in work.read_text()
+    events = _ledger_events(tmp_path)
+    assert [event["event_type"] for event in events] == [
+        "candidate_seen",
+        "state_transition",
+        "candidate_confirmed",
+    ]
+    assert events[1]["source"] == "completion_candidate"
+
+
+def test_exact_canonical_id_candidate_can_confirm_without_extra_task_id(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Fixed login timeout task_id::tsk_login\n")
+
+    proc = _run(["completion-candidates", "confirm", _candidate_id(scan)], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["ok"] is True
+    assert payload["candidate"]["status"] == "confirmed"
+    assert "Fix login timeout" not in work.read_text()
+
+
+def test_fallback_only_candidate_cannot_confirm_without_supplied_canonical_id(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Work
+
+## 🔴 Q1
+- [ ] **Legacy title only** area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Legacy title only\n")
+
+    proc = _run(["completion-candidates", "confirm", _candidate_id(scan)], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 2
+    assert payload["error"]["code"] == "explicit-task-id-required"
+    assert "Legacy title only" in work.read_text()
+
+
+def test_reject_and_snooze_remove_candidates_from_default_list(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(
+        tmp_path,
+        env,
+        "- Ship alpha milestone task_id::tsk_ship\n- Fix login timeout task_id::tsk_login\n",
+    )
+    rejected_id = _candidate_id(scan, 0)
+    snoozed_id = _candidate_id(scan, 1)
+
+    reject = _run(["completion-candidates", "reject", rejected_id, "--reason", "not done"], env)
+    snooze_until = (date.today() + timedelta(days=7)).isoformat()
+    snooze = _run(["completion-candidates", "snooze", snoozed_id, "--until", snooze_until], env)
+    listed = _run(["completion-candidates", "list"], env)
+    listed_all = _run(["completion-candidates", "list", "--all"], env)
+
+    assert reject.returncode == 0
+    assert snooze.returncode == 0
+    assert _payload(listed)["total"] == 0
+    all_payload = _payload(listed_all)
+    statuses = {candidate["candidate_id"]: candidate["status"] for candidate in all_payload["candidates"]}
+    assert statuses[rejected_id] == "rejected"
+    assert statuses[snoozed_id] == "snoozed"
+
+
+def test_duplicate_candidate_is_terminal_and_links_target(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(
+        tmp_path,
+        env,
+        "- Ship alpha milestone task_id::tsk_ship\n- Fix login timeout task_id::tsk_login\n",
+    )
+    duplicate_id = _candidate_id(scan, 1)
+    target_id = _candidate_id(scan, 0)
+
+    proc = _run(["completion-candidates", "duplicate", duplicate_id, "--of", target_id], env)
+    listed = _run(["completion-candidates", "list"], env)
+    listed_all = _run(["completion-candidates", "list", "--all"], env)
+
+    assert proc.returncode == 0
+    payload = _payload(proc)
+    assert payload["candidate"]["status"] == "duplicate"
+    assert payload["candidate"]["duplicate_of"] == target_id
+    assert duplicate_id not in {item["candidate_id"] for item in _payload(listed)["candidates"]}
+    assert duplicate_id in {item["candidate_id"] for item in _payload(listed_all)["candidates"]}
+
+
+def test_apply_failed_keeps_candidate_retryable_and_board_unchanged(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+    candidate_id = _candidate_id(scan)
+    original = work.read_text()
+
+    work.write_text(original.replace("- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery\n", ""))
+    proc = _run(["completion-candidates", "confirm", candidate_id], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 2
+    assert payload["error"]["code"] == "canonical-id-resolution-failed"
+    assert payload["candidate"]["status"] == "apply_failed"
+    assert any(event["event_type"] == "candidate_apply_failed" for event in _ledger_events(tmp_path))
+
+
+def test_confirm_restores_task_state_when_candidate_event_append_fails(tmp_path, monkeypatch):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+    candidate_id = _candidate_id(scan)
+    original = work.read_text()
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(task_records, "get_tasks_file", lambda personal=False: (work, "obsidian"))
+
+    real_append = task_transitions.append_event
+
+    def fail_candidate_confirmed(event, path=None):
+        if event.get("event_type") == "candidate_confirmed":
+            raise OSError("simulated candidate event append failure")
+        return real_append(event, path=path)
+
+    monkeypatch.setattr(task_transitions, "append_event", fail_candidate_confirmed)
+
+    result = completion_candidates.confirm_candidate(candidate_id)
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "ledger-append-failed"
+    assert work.read_text() == original
+    assert not list((tmp_path / "daily").glob("*.md"))
+    event_types = [event["event_type"] for event in _ledger_events(tmp_path)]
+    assert event_types == ["candidate_seen", "candidate_apply_failed"]
+
+
+def test_malformed_ledger_blocks_candidate_projection(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    (tmp_path / "events.jsonl").write_text("{not json}\n")
+
+    proc = _run(["completion-candidates", "list"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 2
+    assert payload["error"]["code"] == "malformed-ledger"
+    assert payload["error"]["malformed"][0]["line_number"] == 1
+
+
+def test_scan_daily_note_uses_configured_notes_directory(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    notes_dir = tmp_path / "daily"
+    notes_dir.mkdir()
+    today = date.today().isoformat()
+    (notes_dir / f"{today}.md").write_text("- Write onboarding docs task_id::tsk_docs\n")
+
+    proc = _run(["completion-candidates", "scan", "--date", today], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["totals"]["created"] == 1
+    assert payload["created"][0]["source"]["type"] == "daily_note"

--- a/tests/test_completion_candidates.py
+++ b/tests/test_completion_candidates.py
@@ -27,6 +27,18 @@ def _write_work_file(tmp_path, content=None):
     return work
 
 
+def _write_personal_file(tmp_path):
+    personal = tmp_path / "Personal Tasks.md"
+    personal.write_text(
+        """# Personal
+
+## 🔴 Q1
+- [ ] **Buy replacement filter** task_id::tsk_filter area:: Home
+"""
+    )
+    return personal
+
+
 def _env(tmp_path, work):
     env = os.environ.copy()
     env["TASK_TRACKER_WORK_FILE"] = str(work)
@@ -189,6 +201,24 @@ def test_reject_and_snooze_remove_candidates_from_default_list(tmp_path):
     assert statuses[snoozed_id] == "snoozed"
 
 
+def test_list_mark_shown_preserves_default_snooze_filter(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+    candidate_id = _candidate_id(scan)
+    snooze_until = (date.today() + timedelta(days=7)).isoformat()
+
+    snooze = _run(["completion-candidates", "snooze", candidate_id, "--until", snooze_until], env)
+    listed = _run(["completion-candidates", "list", "--mark-shown"], env)
+    listed_all = _run(["completion-candidates", "list", "--all"], env)
+
+    assert snooze.returncode == 0
+    assert _payload(listed)["total"] == 0
+    all_candidates = _payload(listed_all)["candidates"]
+    assert all_candidates[0]["candidate_id"] == candidate_id
+    assert all_candidates[0]["status"] == "snoozed"
+
+
 def test_duplicate_candidate_is_terminal_and_links_target(tmp_path):
     work = _write_work_file(tmp_path)
     env = _env(tmp_path, work)
@@ -212,6 +242,20 @@ def test_duplicate_candidate_is_terminal_and_links_target(tmp_path):
     assert duplicate_id in {item["candidate_id"] for item in _payload(listed_all)["candidates"]}
 
 
+def test_duplicate_candidate_rejects_self_reference(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone task_id::tsk_ship\n")
+    candidate_id = _candidate_id(scan)
+
+    proc = _run(["completion-candidates", "duplicate", candidate_id, "--of", candidate_id], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 2
+    assert payload["error"]["code"] == "self-duplicate-blocked"
+    assert _payload(_run(["completion-candidates", "list"], env))["total"] == 1
+
+
 def test_apply_failed_keeps_candidate_retryable_and_board_unchanged(tmp_path):
     work = _write_work_file(tmp_path)
     env = _env(tmp_path, work)
@@ -227,6 +271,69 @@ def test_apply_failed_keeps_candidate_retryable_and_board_unchanged(tmp_path):
     assert payload["error"]["code"] == "canonical-id-resolution-failed"
     assert payload["candidate"]["status"] == "apply_failed"
     assert any(event["event_type"] == "candidate_apply_failed" for event in _ledger_events(tmp_path))
+
+
+def test_scan_rejects_conflicting_file_and_date_sources(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    source = tmp_path / "done.md"
+    source.write_text("- Ship alpha milestone task_id::tsk_ship\n")
+
+    proc = _run(
+        [
+            "completion-candidates",
+            "scan",
+            "--file",
+            str(source),
+            "--date",
+            date.today().isoformat(),
+        ],
+        env,
+    )
+    payload = _payload(proc)
+
+    assert proc.returncode == 2
+    assert payload["error"]["code"] == "conflicting-scan-sources"
+    assert not (tmp_path / "events.jsonl").exists()
+
+
+def test_personal_candidate_lifecycle_uses_personal_ledger_without_override(tmp_path):
+    work = _write_work_file(tmp_path)
+    personal = _write_personal_file(tmp_path)
+    env = _env(tmp_path, work)
+    env["TASK_TRACKER_PERSONAL_FILE"] = str(personal)
+    env.pop("TASK_TRACKER_LEDGER_FILE")
+
+    scan = _run(
+        [
+            "--personal",
+            "completion-candidates",
+            "scan",
+        ],
+        env,
+        input_text="- Buy replacement filter task_id::tsk_filter\n",
+    )
+    scan_payload = _payload(scan)
+    candidate_id = _candidate_id(scan_payload)
+    confirm = _run(["--personal", "completion-candidates", "confirm", candidate_id], env)
+    list_payload = _payload(_run(["--personal", "completion-candidates", "list"], env))
+
+    work_ledger = work.with_suffix(work.suffix + ".events.jsonl")
+    personal_ledger = personal.with_suffix(personal.suffix + ".events.jsonl")
+    personal_events = [
+        json.loads(line) for line in personal_ledger.read_text().splitlines() if line.strip()
+    ]
+
+    assert scan.returncode == 0
+    assert confirm.returncode == 0
+    assert list_payload["total"] == 0
+    assert not work_ledger.exists()
+    assert [event["event_type"] for event in personal_events] == [
+        "candidate_seen",
+        "state_transition",
+        "candidate_confirmed",
+    ]
+    assert "Buy replacement filter" not in personal.read_text()
 
 
 def test_confirm_restores_task_state_when_candidate_event_append_fails(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
- Add a ledger-backed completion candidate inbox for daily-log/EOD-style evidence.
- Add `tasks.py completion-candidates` scan/list/show/confirm/reject/duplicate/snooze commands.
- Keep scan read-only for task state; confirmation completes only through canonical ID-only `complete_by_id()`.
- Make candidate confirmation atomic with task completion by appending the candidate-confirmed event inside the rollback-protected completion transaction.
- Document the 108C plan, command surface, and schema contract.

## Why
108A/108B gave us durable task IDs, one parser-backed task record shape, and ID-only completion. 108C adds the review inbox for completion evidence without reintroducing fuzzy/title auto-mutation.

## Scope boundaries
- No Gmail/calendar/session/Lobster/Telegram ingestion.
- No standup/weekly/EOD UX redesign.
- No bulk auto-confirm.
- No title/fuzzy/fallback-ID mutation; those require explicit `--task-id`.

## Size
[size/exempt: 108C is a cohesive product slice requiring the candidate model, CLI wiring, regression tests, docs/schema updates, and saved plan. Natural follow-up seam is external evidence ingestion after this inbox lands.]

## Verification
- `python3 -m pytest -q` -> 178 passed
- `bash scripts/ci/check-public-hygiene.sh` -> passed
- `python3 -m py_compile scripts/completion_candidates.py scripts/tasks.py scripts/task_transitions.py`
- `python3 scripts/tasks.py completion-candidates --help`
- `python3 scripts/tasks.py completion-candidates scan --help`
- `python3 scripts/tasks.py completion-candidates confirm --help`
- `/home/art/.local/bin/markdownlint README.md SKILL.md references/commands.md references/task-primitives-schema-v1.md`
- `git diff --check`

Generated with AI assistance.