### PR TITLE
feat(tasks): wire completion inbox into workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Completion evidence candidates are suggestions stored in the ledger. Scanning
 daily-log/EOD-style evidence never changes active tasks. Candidate confirmation
 uses the same canonical-ID completion path as `tasks.py done`.
 
+Candidate JSON distinguishes direct confirmation from suggestions:
+`confirmable_task_id` appears only for exact canonical ID/link evidence.
+Title, fuzzy, fallback, and normalized-title evidence expose `suggested_match`
+and still require an explicit canonical `--task-id`. Standup, EOD, weekly, and
+workflow-control surfaces may show candidate counts and IDs, but they must not
+auto-complete tasks. Gmail, calendar, and session-log evidence ingestion remains
+deferred.
+
 ## Development
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,10 +89,15 @@ python3 scripts/tasks.py --personal done "tsk_personal"
 python3 scripts/tasks.py completion-candidates scan --file /tmp/done-log.md
 python3 scripts/tasks.py completion-candidates list
 python3 scripts/tasks.py completion-candidates confirm cand_example --task-id tsk_example
+python3 scripts/completion_inbox_control.py list
+python3 scripts/completion_inbox_control.py confirm cand_example --task-id tsk_example
 ```
 
 Completion candidates are evidence suggestions. Scanning does not mutate active
-tasks; confirmation must resolve to a canonical `task_id::`.
+tasks; confirmation must resolve to a canonical `task_id::`. Workflow wrappers
+such as Telegram/Lobster should call `completion_inbox_control.py` or the
+`completion-candidates` command group by candidate ID. They must not call
+`done` by title, fuzzy match, fallback ID, quick ID, or list position.
 
 ### Backlog ops
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,7 @@ graph TD
         TR["task_repair.py"]
         TT["task_transitions.py"]
         REC["task_records.py"]
+        EM["evidence_matching.py"]
         LINES["task_lines.py"]
         SC["standup_common.py"]
     end
@@ -282,6 +283,7 @@ sequenceDiagram
 | `completion-candidates list/show` | `--all`, `--mark-shown` | Review candidate inbox and event history |
 | `completion-candidates confirm` | `--task-id TASK_ID` | Complete through canonical ID-only `done` semantics |
 | `completion-candidates reject/duplicate/snooze` | `--reason`, `--of`, `--until YYYY-MM-DD` | Record candidate decisions without task writes |
+| `completion_inbox_control.py` | `list/show/reject/snooze/confirm` | Workflow-safe control wrapper over existing inbox commands |
 | `blockers` | `--person NAME` | Show blocking tasks |
 | `archive` | | Archive done tasks to quarterly file |
 
@@ -349,6 +351,7 @@ sequenceDiagram
 | `tasks.py completion-candidates list/show` | Ledger | Ledger only with `--mark-shown` |
 | `tasks.py completion-candidates confirm` | Ledger, task board, daily notes | Task board, daily note, ledger |
 | `tasks.py completion-candidates reject/duplicate/snooze` | Ledger | Ledger candidate events |
+| `completion_inbox_control.py` | Ledger, task board through confirm only | Delegates to existing inbox decision paths |
 | `tasks.py archive` | Daily notes | Quarterly archive |
 | `standup.py` | Task board, daily notes, calendar | — |
 | `personal_standup.py` | Task board, daily notes, calendar | — |

--- a/docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
+++ b/docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md
@@ -60,7 +60,11 @@ The broader product requirements still stand: active-board markdown owns editabl
 
 - PR #108B: consolidate parser and mutation boundaries around one `TaskRecord` contract and remove duplicate task-line mutation helpers.
 - PR #108C: reintroduce completion evidence as an inbox that creates suggestions only and applies confirmed items through ID-only `done`.
-- Later Lobster PR: wire standup, weekly review, Telegram DONEs, calendar, email, and session extraction to the stable task-tracker commands.
+- PR #108D: wire the existing completion inbox into standup, EOD, Telegram, and
+  Lobster workflows after extracting shared evidence matching and clarifying
+  candidate JSON confirmability semantics.
+- Later ingestion PR: add Gmail, calendar, session-log, and other noisy evidence
+  sources only after the workflow-consumption loop is proven.
 - Later product slice: weekly disposition, frozen tasks, delegated/backlog first-class states, and capped daily/EOD UX.
 
 ---
@@ -457,7 +461,13 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 2. **PR #108B:** Parser and mutation consolidation. Land U6.
 3. **PR #108B hardening:** Close the post-108B Oracle P1s before evidence inbox: ledger malformed-line reporting, complete-by-ID rollback around daily-log/board/ledger writes, and weekly archive cleanup through the shared line helper. See `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`.
 4. **PR #108C:** Completion evidence inbox. Land U7.
-5. **Later workflow PR:** Update Lobster/Telegram/standup/weekly/EOD workflows to consume canonical IDs and evidence suggestions.
+5. **PR #108D:** Workflow consumption. Extract shared evidence matching,
+   clarify `confirmable_task_id` versus `suggested_match`, and wire standup,
+   EOD, weekly, Telegram, and Lobster surfaces to consume existing inbox
+   commands without auto-confirming. See
+   `docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md`.
+6. **Later ingestion PR:** Add Gmail, calendar, session-log, and other noisy
+   evidence sources only after 108D proves the review/confirm workflow.
 
 ---
 
@@ -465,7 +475,8 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 
 - Update top-level docs in #108A to describe the identity kernel and deferred work accurately.
 - Keep the broad vNext requirements in `lobster-workflows:docs/brainstorms/2026-05-20-task-tracker-vnext-requirements.md` as product direction, but do not let the reduced PR claim full coverage.
-- Add or update follow-up plan/issue text for #108B and #108C once #108A is split.
+- Add or update follow-up plan/issue text for #108B, #108C, #108D, and the
+  later workflow PR as the sequence advances.
 
 ---
 
@@ -475,6 +486,12 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 - #108B is ready when standup, weekly, EOD, and primitive summaries consume one canonical task record shape and no write path bypasses the kernel.
 - #108B hardening is ready when malformed ledger lines are no longer silent, completion rollback covers daily-log and board write failures, and weekly stale cleanup uses line-number-verified removal.
 - #108C is ready when evidence candidates can be created, deduped, decided, retried, and applied only through ID-only done.
+- #108D is ready when workflow surfaces can list/show/reject/snooze/confirm
+  existing candidates by candidate ID, all confirmation routes through the
+  existing inbox command and ID-only completion kernel, candidate JSON separates
+  `confirmable_task_id` from `suggested_match`, and no workflow path mutates
+  tasks from title, fuzzy, fallback, quick ID, calendar, Gmail, session note, or
+  list position.
 
 ---
 
@@ -485,3 +502,4 @@ For #108A, only the solid arrows are in scope. The dashed evidence path is delib
 - `lobster-workflows:docs/ideation/2026-05-20-task-tracker-radical-simplification-ideas.md`
 - `lobster-workflows:docs/plans/2026-05-20-003-feat-task-tracker-vnext-plan.md`
 - Oracle architecture review pasted in the planning conversation on 2026-05-20
+- Post-108C Oracle progress reviews pasted in the planning conversation on 2026-05-21

--- a/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
+++ b/docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md
@@ -56,7 +56,11 @@ That means 108A made the core safer, but the surrounding workflow code can still
 ### Deferred to Follow-Up Work
 
 - PR #108C: evidence inbox that creates suggestions only and applies confirmed items through ID-only `done`.
-- Later workflow PR: wire Lobster standup, Telegram DONEs, weekly review, and cron flows to canonical IDs.
+- PR #108D: workflow-consumption wiring after the evidence inbox, including
+  shared evidence matching, clearer candidate JSON confirmability, and
+  standup/EOD/Telegram/Lobster surfaces over existing inbox commands.
+- Later ingestion PR: add Gmail, calendar, session-log, and other noisy evidence
+  sources only after 108D proves the review/confirm workflow.
 - Later UX PR: capped daily/EOD decision briefs, stale-task audits, freeze box, and proactive completion prompts.
 - Later product slice: backlog/delegation/frozen states with a real state-transition contract.
 
@@ -411,7 +415,11 @@ The important boundary is that read surfaces may consume fallback diagnostics, b
 - **Agent behavior:** Agents get one canonical ID field to carry through standup, weekly review, and direct DONE commands.
 - **Workflow safety:** EOD and daily-log parsing stop competing with the ID-only kernel.
 - **Compatibility:** Existing read/report commands should keep broadly similar output, but unsafe default write behavior may be blocked or moved behind explicit legacy flags.
-- **Future sequencing:** 108C can build an evidence inbox on top of shared records instead of inheriting current fuzzy write ambiguity.
+- **Future sequencing:** 108C can build an evidence inbox on top of shared
+  records instead of inheriting current fuzzy write ambiguity. Post-108C, 108D
+  should extract the evidence matcher from private `tasks.py` helpers, clarify
+  candidate JSON confirmability, and wire standup/EOD/Telegram/Lobster surfaces
+  over existing inbox commands before adding Gmail/calendar/session ingestion.
 
 ---
 
@@ -438,6 +446,9 @@ The important boundary is that read surfaces may consume fallback diagnostics, b
 6. Make EOD/daily-log fuzzy matching report-only by default.
 7. Update docs/help and run the full local verification suite.
 8. Follow up with 108B hardening before 108C: malformed ledger reporting, completion rollback hardening, and weekly archive cleanup through shared line helpers.
+9. Follow up with 108D workflow consumption before noisy source ingestion:
+   matcher extraction, candidate JSON clarity, standup/EOD candidate visibility,
+   and Telegram/Lobster inbox controls.
 
 ---
 
@@ -466,4 +477,5 @@ The important boundary is that read surfaces may consume fallback diagnostics, b
 - `lobster-workflows:docs/brainstorms/2026-05-20-task-tracker-vnext-requirements.md`
 - `lobster-workflows:docs/debug/2026-05-20-task-tracker-ux-failures.md`
 - `lobster-workflows:docs/ideation/2026-05-20-task-tracker-radical-simplification-ideas.md`
+- `docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md`
 - Oracle architecture review pasted in the planning conversation on 2026-05-20

--- a/docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md
+++ b/docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md
@@ -22,6 +22,13 @@ Build PR #108C as the narrow completion evidence inbox promised by the 108A/108B
 
 The next missing piece is a safe place for "I probably did this" evidence to accumulate without pretending the evidence completed a task. Today `tasks.py ingest-daily-log` can rank matches, but the output is ephemeral. A user or agent has no durable inbox to review, reject, snooze, dedupe, or confirm later. 108C should add that inbox while preserving the source-of-truth boundary: active board markdown is current state; the ledger is audit/candidate history; daily notes are human-facing evidence.
 
+Final Oracle review found no P0 blocker in 108C and judged the foundation good
+enough to build on. The next PR should not add Gmail, calendar, or session-log
+ingestion. It should extract evidence matching out of private `tasks.py` helpers,
+make candidate JSON harder to misuse, and wire standup, EOD, Telegram, and
+Lobster surfaces over the existing inbox. That work is tracked in
+`docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md`.
+
 ---
 
 ## Requirements
@@ -55,6 +62,9 @@ The next missing piece is a safe place for "I probably did this" evidence to acc
 
 ### Deferred to Follow-Up Work
 
+- PR #108D workflow consumption before noisy source ingestion: shared evidence
+  matching, `confirmable_task_id` versus `suggested_match`, standup/EOD/weekly
+  candidate visibility, and Telegram/Lobster inbox controls.
 - Gmail, calendar, session-log, Telegram DONEs, and Lobster cron ingestion.
 - Morning standup and EOD UX redesign.
 - Bulk confirm or auto-confirm.
@@ -335,6 +345,10 @@ flowchart TD
 
 - Final CLI spelling can be `completion-candidates` or a shorter alias if local command conventions make one clearly better.
 - Exact candidate event names may vary, but they must remain distinct from `state_transition` events.
+- 108C candidate payloads are safe in code, but 108D should make JSON harder for
+  agents to misuse: exact ID/link evidence may expose `confirmable_task_id`,
+  while title/fuzzy/fallback evidence should expose only `suggested_match` and
+  review-required metadata.
 - Candidate expiry policy can be manual or simple time-window based in this slice; do not add scheduler/cron expiry yet.
 - Daily-note scan line-number fidelity may depend on existing extractor detail. If source line numbers are not available, use a stable source pointer based on date/path plus normalized summary and timestamp where available.
 
@@ -347,6 +361,9 @@ flowchart TD
 - Run CLI help checks for `tasks.py done`, `tasks.py ingest-daily-log`, and new completion-candidate commands.
 - Run public hygiene and markdown lint on changed docs.
 - Manually inspect sample JSON for one exact-ID candidate, one fuzzy suggestion, one fallback-only candidate, one rejected candidate, and one apply-failed candidate.
+- After 108C lands, run an Oracle/Codex checkpoint before external ingestion.
+  The final checkpoint recommends 108D as workflow consumption plus matcher
+  extraction, with Gmail/calendar/session ingestion deferred one more PR.
 
 ---
 
@@ -357,3 +374,4 @@ flowchart TD
 - `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`
 - `docs/ARCHITECTURE.md`
 - Oracle progress review pasted in the planning conversation on 2026-05-21
+- Post-108C Oracle progress reviews pasted in the planning conversation on 2026-05-21

--- a/docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md
+++ b/docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md
@@ -1,0 +1,446 @@
+---
+title: feat: wire task tracker inbox into workflows
+type: feat
+status: active
+date: 2026-05-21
+origin: docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# feat: wire task tracker inbox into workflows
+
+## Summary
+
+Build the next PR after 108C as a workflow-consumption slice. The foundation is
+good enough to build on: board markdown owns current task state, `task_id::` is
+the mutation identity, `TaskRecord` is the shared read model, JSONL stores audit
+and candidate history, and completion candidates confirm through the ID-only
+`complete_by_id()` kernel.
+
+The next PR should wire that inbox into the daily product loop without adding
+new external evidence ingestion. It should extract evidence matching out of the
+CLI layer, make candidate JSON harder to misuse, then expose existing inbox
+actions through standup, EOD, Telegram, and Lobster workflow surfaces.
+
+**Target repo:** task-tracker-openclaw-skill. Paths in this plan are
+repo-relative. Lobster workflow paths are referenced with the `lobster-workflows:`
+repo alias.
+
+---
+
+## Problem Frame
+
+108C created a durable completion evidence inbox, but the user path is still
+mostly CLI-level: scan, list/show, confirm/reject/snooze. The next product gap
+is not Gmail, calendar, or session-log ingestion. Those sources would multiply
+ambiguity, privacy, source-pointer, dedupe, and false-positive risk before the
+local workflow loop proves itself.
+
+The safer next move is to let existing daily surfaces consume the inbox:
+
+- Standup and EOD should show candidate counts, candidate IDs, suggested task
+  IDs, and clear "review required" language.
+- Telegram and Lobster wrappers should list, show, reject, snooze, and confirm
+  candidates by candidate ID and canonical task ID.
+- Confirmation must still call the existing `completion-candidates confirm`
+  command and preserve its canonical-ID guardrails.
+- No workflow path should auto-confirm or call `done` from title, fuzzy match,
+  fallback ID, quick ID, calendar event, Gmail message, session note, or list
+  position.
+
+Oracle's final 2026-05-21 architecture checkpoint found no P0s. It did identify
+two small blockers before workflow wiring: evidence matching should move out of
+`tasks.py`, and candidate JSON should separate direct confirmability from
+suggestions so agents cannot mistake a fuzzy/title suggestion for authority to
+complete a task.
+
+---
+
+## Requirements
+
+- R1. Evidence matching must move from private `tasks.py` helpers into a
+  non-CLI module such as `scripts/evidence_matching.py`.
+- R2. Both `tasks.py ingest-daily-log` and `completion-candidates scan` must use
+  the shared matcher module.
+- R3. Candidate JSON must expose `confirmable_task_id` only when exact ID/link
+  evidence is safe to confirm without an extra `--task-id`.
+- R4. Title, fuzzy, fallback, and normalized-title evidence may expose
+  `suggested_match`, but must not expose `confirmable_task_id`.
+- R5. Standup, EOD, and weekly workflow output must show candidate counts,
+  candidate IDs, suggested task IDs when available, and explicit review-required
+  language.
+- R6. Standup, EOD, and weekly workflow output must not auto-confirm candidates
+  or call `done`.
+- R7. Telegram and Lobster wrappers must operate as control surfaces over the
+  existing inbox: list, show, reject, snooze, and confirm by candidate ID.
+- R8. Candidate confirmation from any wrapper must call
+  `completion-candidates confirm` or equivalent existing inbox code and must
+  require a canonical task ID unless the candidate is exact ID/link evidence.
+- R9. Gmail, calendar, and session-log evidence ingestion must remain deferred.
+- R10. Docs and CLI help must make the safe path obvious: scan evidence, review
+  candidate, confirm by canonical ID.
+
+**Origin traceability:** This plan updates the deferred workflow step from
+`docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md` and the
+post-108C follow-up notes in
+`docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md`.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Shared evidence matcher extraction.
+- Candidate JSON clarification around `confirmable_task_id` and
+  `suggested_match`.
+- Standup/EOD/weekly read surfaces that display inbox status and review actions.
+- Telegram/Lobster workflow wrappers over existing candidate commands.
+- Tests proving workflow surfaces do not mutate canonical task state from unsafe
+  evidence.
+- Docs and help text for the workflow-consumption path.
+
+### Deferred to Follow-Up Work
+
+- Gmail evidence ingestion.
+- Calendar evidence ingestion.
+- Session-log evidence ingestion.
+- Bulk confirm, auto-confirm, or autonomous DONE application.
+- First-class delegated/backlog/frozen lifecycle states.
+- Broader daily/EOD/weekly UX redesign beyond candidate visibility and actions.
+- Ledger replay as active-board source of truth.
+
+### Out of Scope
+
+- Any title, fuzzy, fallback ID, quick ID, calendar event, Gmail message,
+  session note, list-position, or local numeric-ID mutation.
+- Any new credentialed external source adapter.
+- Any change that makes Telegram a new evidence-ingestion source. Telegram is a
+  control surface in this PR.
+- Any broad replacement of the Obsidian editable board model.
+
+---
+
+## Assumptions
+
+- The task-tracker repo can add or adjust wrapper scripts/docs for workflow
+  consumption, while Lobster-specific cron or Telegram wiring may land in
+  `lobster-workflows:` if the implementation reaches that repo.
+- Existing candidate lifecycle behavior from 108C is retained: scan is
+  non-mutating, strict malformed-ledger reads block unsafe projections, and
+  confirm applies through ID-only completion.
+- Candidate JSON may add clearer fields while preserving older fields where
+  reasonable for compatibility.
+- Weekly output is a read surface in this PR, not a weekly archive or closeout
+  redesign.
+
+---
+
+## Key Technical Decisions
+
+- **Wire workflows before adding noisy sources.** Standup, EOD, Telegram, and
+  Lobster usage will validate the inbox loop with low new data-source risk.
+- **Extract the matcher first.** Workflow code should import a stable domain
+  module, not private CLI helpers.
+- **Separate confirmability from suggestion.** `confirmable_task_id` means the
+  candidate can be confirmed without extra task selection; `suggested_match`
+  means "review this possible task."
+- **Keep Telegram as control, not ingestion.** Telegram actions may review and
+  decide existing candidates, but they should not create a new Telegram DONE
+  evidence source in this PR.
+- **Keep completion centralized.** Every workflow confirmation path routes
+  through the existing candidate confirmation command or core function.
+
+---
+
+## High-Level Technical Design
+
+This diagram is directional guidance for review, not an implementation
+specification.
+
+```mermaid
+flowchart TD
+  Evidence[existing daily/EOD evidence] --> Matcher[evidence_matching module]
+  Matcher --> Candidates[completion-candidates scan]
+  Candidates --> Ledger[JSONL candidate events]
+  Standup[standup output] --> InboxRead[completion-candidates list/show]
+  EOD[EOD output] --> InboxRead
+  Telegram[Telegram controls] --> InboxRead
+  Lobster[Lobster workflow controls] --> InboxRead
+  Telegram --> Decide[confirm/reject/snooze by candidate ID]
+  Lobster --> Decide
+  Decide --> Confirm[completion-candidates confirm]
+  Confirm --> Done[complete_by_id]
+```
+
+---
+
+## Implementation Units
+
+### U1. Shared Evidence Matcher Extraction
+
+Files to inspect/change:
+
+- `scripts/evidence_matching.py` (new)
+- `scripts/tasks.py`
+- `scripts/completion_candidates.py`
+- `scripts/task_records.py`
+- `tests/test_task_primitives.py`
+- `tests/test_completion_candidates.py`
+
+Approach:
+
+Move evidence line extraction, task catalog construction, record loading, and
+match classification out of `tasks.py` into a small module. Keep `tasks.py` as a
+CLI adapter. Preserve the current read-only ingest behavior and candidate scan
+behavior while removing private-helper imports from `completion_candidates.py`.
+
+Test scenarios:
+
+- `completion_candidates.py` no longer imports private `_...` helpers from
+  `tasks.py`.
+- `tasks.py ingest-daily-log` and `completion-candidates scan` produce equivalent
+  match decisions for exact ID, title-only, fuzzy, and fallback-only evidence.
+- Duplicate title and fallback-only evidence remain suggestions, not mutation
+  authority.
+- Malformed task records or task-file read failures still produce the existing
+  safe error/degraded behavior.
+
+### U2. Candidate JSON Confirmability Semantics
+
+Files to inspect/change:
+
+- `scripts/completion_candidates.py`
+- `scripts/evidence_matching.py`
+- `references/task-primitives-schema-v1.md`
+- `tests/test_completion_candidates.py`
+
+Approach:
+
+Add or standardize two JSON concepts: `confirmable_task_id` and
+`suggested_match`. Only exact canonical ID/link evidence may set
+`confirmable_task_id`. Title, normalized-title, fuzzy, and fallback evidence may
+include `suggested_match`, alternatives, confidence, and review notes, but must
+not look directly confirmable without a supplied canonical task ID.
+
+Test scenarios:
+
+- Exact canonical ID/link candidate includes `confirmable_task_id`.
+- Title-only candidate includes `suggested_match` but not `confirmable_task_id`.
+- Fuzzy candidate includes `suggested_match` but not `confirmable_task_id`.
+- Fallback-only candidate includes diagnostic match data but not
+  `confirmable_task_id`.
+- Confirmation without `--task-id` still succeeds only for exact ID/link
+  candidates.
+- Confirmation without `--task-id` still fails for title, fuzzy, and fallback
+  candidates.
+
+### U3. Standup, EOD, and Weekly Candidate Visibility
+
+Files to inspect/change:
+
+- `scripts/standup.py`
+- `scripts/eod_review.py`
+- `scripts/weekly_review.py`
+- `scripts/tasks.py`
+- `tests/test_standup_compact.py`
+- `tests/test_task_primitives.py`
+- `tests/test_completion_candidates.py`
+
+Approach:
+
+Add read-only candidate summaries to the daily review surfaces. Output should
+show candidate counts, candidate IDs, suggested canonical task IDs when present,
+and clear review-required language. The output should be concise enough for
+standup/EOD usage and explicit enough that agents know which command to call
+next. These surfaces must not mutate board, daily log, or ledger state except for
+existing explicit read-side behavior such as marking candidates shown only if
+already supported and intentionally invoked.
+
+Test scenarios:
+
+- Standup compact output includes candidate count and candidate IDs.
+- EOD output includes candidate count and candidate IDs.
+- Weekly output includes candidate count or a review pointer without archive or
+  closeout mutation.
+- Title/fuzzy/fallback candidates are labeled review-required.
+- Standup/EOD/weekly code does not call `done` or `complete_by_id`.
+- Board and daily-log files remain unchanged after read-only workflow rendering.
+
+### U4. Telegram and Lobster Inbox Controls
+
+Files to inspect/change:
+
+- `scripts/tasks.py`
+- `README.md`
+- `SKILL.md`
+- `references/commands.md`
+- `lobster-workflows:scripts/`
+- `lobster-workflows:docs/`
+- `tests/test_completion_candidates.py`
+- `tests/test_tasks.py`
+
+Approach:
+
+Expose workflow-friendly commands or wrapper scripts that list, show, reject,
+snooze, and confirm candidates by candidate ID. If Lobster-specific changes are
+needed, keep them as thin wrappers over task-tracker commands. Telegram should
+act as a control surface for existing candidates, not as a new source that scans
+messages into candidates.
+
+Test scenarios:
+
+- Wrapper list/show commands return candidate IDs and candidate status.
+- Wrapper reject and snooze commands call existing candidate decision paths.
+- Wrapper confirm calls existing `completion-candidates confirm`.
+- Wrapper confirm requires `--task-id` unless the candidate has
+  `confirmable_task_id`.
+- No wrapper calls `done` by title, fuzzy match, fallback ID, quick ID, or list
+  position.
+- Personal/work ledger separation remains intact through wrapper usage.
+
+### U5. Workflow Safety Regression Suite
+
+Files to inspect/change:
+
+- `tests/test_completion_candidates.py`
+- `tests/test_task_transitions.py`
+- `tests/test_task_primitives.py`
+- `tests/test_standup_compact.py`
+- `tests/test_tasks.py`
+- `tests/fixtures/`
+
+Approach:
+
+Add tests around the whole workflow path, not just storage internals. The suite
+should prove that candidate visibility and wrappers cannot mutate tasks from
+unsafe evidence and that existing 108C failure semantics still hold.
+
+Test scenarios:
+
+- Duplicate title candidates do not auto-complete.
+- Fallback-only candidates cannot confirm without supplied canonical task ID.
+- Malformed ledger blocks candidate list/show/decision.
+- Snoozed candidates become visible/actionable again after the snooze date in
+  the surfaces that display candidates.
+- Apply failure remains retryable.
+- Personal/work ledger separation is preserved.
+- Scans and read-only workflow rendering do not mutate board or daily log.
+- Unsafe sources such as calendar event, Gmail message, session note, quick ID,
+  and list position cannot complete a task through workflow code.
+
+### U6. Docs and Help Updates
+
+Files to inspect/change:
+
+- `README.md`
+- `SKILL.md`
+- `docs/ARCHITECTURE.md`
+- `references/commands.md`
+- `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- `docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md`
+- `lobster-workflows:docs/`
+
+Approach:
+
+Document the safe workflow path in plain operational terms: scan evidence, review
+candidate, confirm by canonical ID. Repeat that Gmail, calendar, and session-log
+ingestion remain deferred. Make clear that Telegram and Lobster are wrappers over
+the existing inbox unless a later PR explicitly scopes new ingestion.
+
+Test scenarios:
+
+- CLI help for candidate commands describes `confirmable_task_id` versus
+  `suggested_match` if those fields are user-facing.
+- Docs say Telegram/Lobster are control surfaces over the inbox.
+- Docs say Gmail/calendar/session ingestion is not part of this PR.
+- Docs do not tell users or agents to complete tasks by title, fuzzy match,
+  fallback ID, quick ID, or list position.
+
+---
+
+## System-Wide Impact
+
+- **Daily workflow:** Standup and EOD start showing the completion inbox instead
+  of leaving it as an isolated CLI feature.
+- **Agent safety:** Agents get explicit candidate IDs, canonical task IDs, and
+  review-required language instead of inferring from fuzzy/title matches.
+- **Workflow integration:** Lobster and Telegram can act on existing candidates
+  without introducing new evidence-source risk.
+- **Future ingestion:** Gmail, calendar, and session-log adapters will consume a
+  matcher module and proven workflow loop rather than CLI internals.
+
+---
+
+## Risks & Dependencies
+
+- **Workflow PR becomes too broad:** keep the first slice to matcher extraction,
+  candidate JSON clarity, and inbox control surfaces. Defer source ingestion.
+- **Telegram is mistaken for evidence ingestion:** docs and tests must frame it
+  as list/show/decision control over existing candidates only.
+- **Candidate summaries get noisy:** show counts and top candidate IDs, with
+  links/commands to drill in instead of dumping the whole inbox.
+- **Wrapper code bypasses safety:** all confirmation paths must call existing
+  candidate confirmation, not `done` directly.
+- **Lobster changes require cross-repo coordination:** keep wrappers thin and
+  command-based so the task-tracker contract remains the source of truth.
+
+---
+
+## Phased Delivery
+
+1. Extract evidence matching into a shared non-CLI module.
+2. Add `confirmable_task_id` and `suggested_match` semantics to candidate JSON.
+3. Add read-only candidate summaries to standup, EOD, and weekly outputs.
+4. Add Telegram/Lobster wrapper controls over list/show/reject/snooze/confirm.
+5. Add workflow safety regression tests.
+6. Update docs/help and run verification.
+
+---
+
+## Documentation Plan
+
+- Update `README.md`, `SKILL.md`, and `references/commands.md` with the safe
+  candidate workflow.
+- Update `docs/ARCHITECTURE.md` to show evidence matching as a module below CLI
+  and workflow wrappers.
+- Update prior plan docs so the next PR is workflow consumption plus matcher
+  extraction, not broad hardening or external ingestion.
+- If Lobster docs are touched, repeat that Telegram/Lobster are control surfaces
+  over the inbox and Gmail/calendar/session ingestion remains deferred.
+
+---
+
+## Verification Strategy
+
+- Run focused workflow and candidate tests:
+  - `pytest -q tests/test_completion_candidates.py`
+  - `pytest -q tests/test_task_primitives.py`
+  - `pytest -q tests/test_standup_compact.py`
+  - `pytest -q tests/test_tasks.py`
+  - `pytest -q tests/test_task_transitions.py`
+- Run `pytest -q` before opening the PR if runtime is acceptable.
+- Run `bash scripts/ci/check-public-hygiene.sh`.
+- Run CLI help checks for `tasks.py completion-candidates`, `tasks.py done`,
+  standup, EOD, and any Telegram/Lobster wrapper scripts.
+- Manually verify duplicate title candidates, fallback-only candidates,
+  malformed ledger, snoozed candidate visibility, apply failure retryability, and
+  personal/work ledger separation.
+
+---
+
+## Sources & References
+
+- `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- `docs/plans/2026-05-21-001-refactor-single-parser-mutation-boundary-plan.md`
+- `docs/plans/2026-05-21-002-hardening-108b-before-evidence-inbox-plan.md`
+- `docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md`
+- `docs/ARCHITECTURE.md`
+- `scripts/tasks.py`
+- `scripts/completion_candidates.py`
+- `scripts/standup.py`
+- `scripts/eod_review.py`
+- `scripts/weekly_review.py`
+- Final Oracle architecture checkpoint pasted in the planning conversation on
+  2026-05-21

--- a/references/commands.md
+++ b/references/commands.md
@@ -97,6 +97,9 @@ python3 scripts/tasks.py completion-candidates reject cand_example \
   --reason "not actually done"
 python3 scripts/tasks.py completion-candidates duplicate cand_example --of cand_original
 python3 scripts/tasks.py completion-candidates snooze cand_example --until 2026-05-28
+python3 scripts/completion_inbox_control.py list
+python3 scripts/completion_inbox_control.py show cand_example
+python3 scripts/completion_inbox_control.py confirm cand_example --task-id tsk_example
 ```
 
 Scanning creates durable candidate events in the ledger, but never mutates the
@@ -104,6 +107,13 @@ task board or completion log. Confirmation is the only task-changing candidate
 action, and it completes through the same canonical-ID `done` path. Exact
 `task_id::` evidence can confirm directly; title, fuzzy, and fallback-only
 suggestions require `--task-id`.
+
+Candidate JSON uses `confirmable_task_id` only for exact canonical ID/link
+evidence that may be confirmed without an extra task selector. Title, fuzzy,
+fallback, and normalized-title evidence should be treated as `suggested_match`
+only. `completion_inbox_control.py` is the stable workflow-control wrapper for
+Telegram, Lobster, and similar shells; it delegates to the same inbox decision
+paths and does not scan new Gmail, calendar, or session-log evidence.
 
 ## Wrapper shortcuts
 

--- a/references/task-primitives-schema-v1.md
+++ b/references/task-primitives-schema-v1.md
@@ -174,6 +174,8 @@ persisted as candidates.
       "summary": "Ship alpha milestone task_id::tsk_ship",
       "normalized_summary": "ship alpha milestone task id tsk_ship",
       "matched_task_id": "tsk_ship",
+      "confirmable_task_id": "tsk_ship",
+      "review_required": false,
       "suggested_match": {
         "task_id": "tsk_ship",
         "title": "Ship alpha milestone",
@@ -204,9 +206,16 @@ Decision commands use the same envelope with command names such as
 Confirmation rules:
 
 - exact `task_id::` or exact link evidence may confirm without `--task-id`
+- `confirmable_task_id` is present only for exact canonical ID/link evidence
 - title, fuzzy, issue-number fallback, and fallback-only matches require
   explicit `--task-id`
+- non-exact evidence may include `suggested_match`, but workflows must treat it
+  as review-required
 - confirmation calls the canonical ID-only completion path and writes a
   `candidate_confirmed` event only after task completion succeeds
 - failed application writes `candidate_apply_failed` and leaves the candidate
   retryable
+
+Workflow wrappers should use `scripts/completion_inbox_control.py` or the
+`completion-candidates` command group. These wrappers review and decide existing
+candidates only; Gmail, calendar, and session-log ingestion remain deferred.

--- a/scripts/candidate_review.py
+++ b/scripts/candidate_review.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Read-only completion candidate review summaries for workflow surfaces."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from completion_candidates import project_candidates
+from task_ledger import MalformedLedgerError
+
+
+def visible_completion_candidates(candidates: list[dict[str, Any]], *, include_all: bool = False) -> list[dict[str, Any]]:
+    if include_all:
+        return candidates
+    today = date.today().isoformat()
+    return [
+        candidate for candidate in candidates
+        if candidate.get("status") != "snoozed"
+        or (candidate.get("snoozed_until") or "") <= today
+    ]
+
+
+def candidate_review_summary(*, personal: bool = False, limit: int = 5) -> dict[str, Any]:
+    try:
+        candidates = visible_completion_candidates(project_candidates(personal=personal))
+    except MalformedLedgerError as exc:
+        return {
+            "available": False,
+            "review_required": True,
+            "error": {
+                "code": "malformed-ledger",
+                "malformed": [
+                    {
+                        "path": item.path,
+                        "line_number": item.line_number,
+                        "message": item.message,
+                    }
+                    for item in exc.malformed
+                ],
+            },
+        }
+    except OSError as exc:
+        return {
+            "available": False,
+            "review_required": True,
+            "error": {"code": "io-error", "message": str(exc)},
+        }
+
+    items = []
+    for candidate in candidates[:limit]:
+        suggested = candidate.get("suggested_match") or {}
+        items.append(
+            {
+                "candidate_id": candidate.get("candidate_id"),
+                "status": candidate.get("status"),
+                "summary": candidate.get("summary"),
+                "confirmable_task_id": candidate.get("confirmable_task_id"),
+                "suggested_task_id": suggested.get("task_id"),
+                "suggested_title": suggested.get("title"),
+                "review_required": candidate.get("review_required", True),
+            }
+        )
+
+    return {
+        "available": True,
+        "review_required": bool(candidates),
+        "total": len(candidates),
+        "items": items,
+        "overflow": max(0, len(candidates) - len(items)),
+        "instructions": "Review candidates; confirm only by candidate ID and canonical task_id.",
+    }

--- a/scripts/completion_candidates.py
+++ b/scripts/completion_candidates.py
@@ -9,6 +9,14 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
+from evidence_matching import (
+    FUZZY_EVIDENCE_LINK_THRESHOLD,
+    FUZZY_REVIEW_THRESHOLD,
+    build_task_catalog,
+    extract_done_lines,
+    match_evidence_line,
+    safe_load_task_records,
+)
 from task_ledger import append_event, ledger_path, new_event, read_events
 from task_transitions import complete_by_id
 from utils import get_tasks_file
@@ -56,6 +64,13 @@ def _candidate_from_seen(event: dict[str, Any]) -> dict[str, Any]:
     candidate.setdefault("candidate_id", event.get("task_id"))
     candidate.setdefault("status", "new")
     candidate.setdefault("history", [])
+    match_metadata = candidate.get("match_metadata") or {}
+    matched_task_id = candidate.get("matched_task_id") or match_metadata.get("matched_task_id")
+    if match_metadata.get("match_type") == "exact-id-or-link" and matched_task_id:
+        candidate.setdefault("confirmable_task_id", matched_task_id)
+        candidate.setdefault("review_required", False)
+    else:
+        candidate.setdefault("review_required", True)
     return candidate
 
 
@@ -147,7 +162,9 @@ def _build_candidate_from_match(item: dict[str, Any], source: dict[str, Any]) ->
     candidate_id = candidate_id_for(source_pointer, summary)
     match_metadata = dict(item.get("match_metadata") or {})
     canonical_task = item.get("canonical_task")
-    return {
+    matched_task_id = match_metadata.get("matched_task_id")
+    is_confirmable = match_metadata.get("match_type") == "exact-id-or-link" and bool(matched_task_id)
+    candidate = {
         "candidate_id": candidate_id,
         "status": "new",
         "source": source_pointer,
@@ -156,8 +173,12 @@ def _build_candidate_from_match(item: dict[str, Any], source: dict[str, Any]) ->
         "normalized_summary": item.get("normalized_title") or _normalize_summary(summary),
         "suggested_match": canonical_task,
         "match_metadata": match_metadata,
-        "matched_task_id": match_metadata.get("matched_task_id"),
+        "matched_task_id": matched_task_id,
+        "review_required": not is_confirmable,
     }
+    if is_confirmable:
+        candidate["confirmable_task_id"] = matched_task_id
+    return candidate
 
 
 def _source_from_file(path: Path) -> tuple[str, dict[str, Any]]:
@@ -172,21 +193,12 @@ def _source_from_daily_note(notes_dir: Path, day: date) -> tuple[str, dict[str, 
 
 
 def _match_evidence_lines(content: str, source: dict[str, Any], *, personal: bool = False) -> list[dict[str, Any]]:
-    from tasks import (
-        FUZZY_EVIDENCE_LINK_THRESHOLD,
-        FUZZY_REVIEW_THRESHOLD,
-        _build_task_catalog,
-        _extract_done_lines,
-        _ingest_match_line,
-        _safe_load_task_records,
-    )
-
-    parsed = _extract_done_lines(content)
-    records = _safe_load_task_records(personal)
-    catalog = _build_task_catalog(records)
+    parsed = extract_done_lines(content)
+    records = safe_load_task_records(personal)
+    catalog = build_task_catalog(records)
     matched = []
     for line in parsed:
-        match = _ingest_match_line(
+        match = match_evidence_line(
             line,
             catalog,
             auto_threshold=FUZZY_EVIDENCE_LINK_THRESHOLD,
@@ -332,7 +344,11 @@ def _candidate_task_id(candidate: dict[str, Any], explicit_task_id: str | None) 
             "code": "explicit-task-id-required",
             "message": "Only exact canonical ID/link evidence can be confirmed without --task-id.",
         }
-    task_id = candidate.get("matched_task_id")
+    task_id = candidate.get("confirmable_task_id")
+    if not task_id:
+        # Compatibility with 108C candidate rows projected before
+        # confirmable_task_id existed.
+        task_id = candidate.get("matched_task_id")
     if not task_id:
         return None, {"code": "canonical-task-id-missing"}
     return task_id, None

--- a/scripts/completion_inbox_control.py
+++ b/scripts/completion_inbox_control.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Workflow-safe controls for the completion candidate inbox.
+
+This script is intentionally a thin wrapper over completion_candidates.py. It is
+for Telegram, Lobster, and other workflow shells that need list/show/decision
+actions without importing the CLI module or calling task completion directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from completion_candidates import (  # noqa: E402
+    confirm_candidate,
+    get_candidate,
+    mark_shown,
+    project_candidates,
+    reject_candidate,
+    snooze_candidate,
+)
+from task_ledger import MalformedLedgerError  # noqa: E402
+
+
+def _payload(command: str, **fields) -> dict:
+    payload = {"schema_version": "v1", "command": command}
+    payload.update(fields)
+    return payload
+
+
+def _print(payload: dict, *, exit_on_error: bool = True) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if exit_on_error and payload.get("ok") is False:
+        sys.exit(2)
+
+
+def _visible(candidates: list[dict], *, include_all: bool = False) -> list[dict]:
+    if include_all:
+        return candidates
+    today = date.today().isoformat()
+    return [
+        candidate for candidate in candidates
+        if candidate.get("status") != "snoozed"
+        or (candidate.get("snoozed_until") or "") <= today
+    ]
+
+
+def _handle(args: argparse.Namespace) -> dict:
+    if args.command == "list":
+        candidates = _visible(
+            project_candidates(include_terminal=args.all, personal=args.personal),
+            include_all=args.all,
+        )
+        if args.mark_shown:
+            for candidate in candidates:
+                if candidate.get("status") == "new":
+                    mark_shown(candidate["candidate_id"], personal=args.personal)
+            candidates = _visible(
+                project_candidates(include_terminal=args.all, personal=args.personal),
+                include_all=args.all,
+            )
+        return _payload("completion-inbox-control list", candidates=candidates, total=len(candidates))
+
+    if args.command == "show":
+        candidate = get_candidate(args.candidate_id, include_terminal=True, personal=args.personal)
+        if candidate is None:
+            return _payload(
+                "completion-inbox-control show",
+                ok=False,
+                error={"code": "candidate-not-found"},
+            )
+        if args.mark_shown and candidate.get("status") == "new":
+            result = mark_shown(args.candidate_id, personal=args.personal)
+            candidate = result.get("candidate")
+        return _payload("completion-inbox-control show", candidate=candidate)
+
+    if args.command == "reject":
+        return _payload(
+            "completion-inbox-control reject",
+            **reject_candidate(args.candidate_id, reason=args.reason, personal=args.personal),
+        )
+
+    if args.command == "snooze":
+        return _payload(
+            "completion-inbox-control snooze",
+            **snooze_candidate(args.candidate_id, until=args.until, personal=args.personal),
+        )
+
+    if args.command == "confirm":
+        return _payload(
+            "completion-inbox-control confirm",
+            **confirm_candidate(args.candidate_id, task_id=args.task_id, personal=args.personal),
+        )
+
+    return _payload("completion-inbox-control", ok=False, error={"code": "unknown-command"})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Workflow-safe completion inbox controls")
+    parser.add_argument("--personal", action="store_true", help="Use Personal Tasks instead of Work Tasks")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = sub.add_parser("list", help="List active completion candidates")
+    list_parser.add_argument("--all", action="store_true", help="Include terminal and future-snoozed candidates")
+    list_parser.add_argument("--mark-shown", action="store_true", help="Record shown events for new candidates")
+
+    show_parser = sub.add_parser("show", help="Show one completion candidate")
+    show_parser.add_argument("candidate_id")
+    show_parser.add_argument("--mark-shown", action="store_true", help="Record a shown event for a new candidate")
+
+    reject_parser = sub.add_parser("reject", help="Reject a completion candidate")
+    reject_parser.add_argument("candidate_id")
+    reject_parser.add_argument("--reason")
+
+    snooze_parser = sub.add_parser("snooze", help="Snooze a completion candidate")
+    snooze_parser.add_argument("candidate_id")
+    snooze_parser.add_argument("--until", required=True, help="Date to resurface candidate, YYYY-MM-DD")
+
+    confirm_parser = sub.add_parser("confirm", help="Confirm candidate through ID-only completion")
+    confirm_parser.add_argument("candidate_id")
+    confirm_parser.add_argument("--task-id", help="Canonical task_id required unless exact ID/link evidence")
+
+    args = parser.parse_args()
+    try:
+        _print(_handle(args))
+    except MalformedLedgerError as exc:
+        _print(
+            _payload(
+                f"completion-inbox-control {args.command}",
+                ok=False,
+                error={
+                    "code": "malformed-ledger",
+                    "malformed": [
+                        {
+                            "path": item.path,
+                            "line_number": item.line_number,
+                            "message": item.message,
+                            "raw_line": item.raw_line,
+                        }
+                        for item in exc.malformed
+                    ],
+                },
+            )
+        )
+    except OSError as exc:
+        _print(
+            _payload(
+                f"completion-inbox-control {args.command}",
+                ok=False,
+                error={"code": "io-error", "message": str(exc)},
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eod_review.py
+++ b/scripts/eod_review.py
@@ -21,6 +21,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from candidate_review import candidate_review_summary
 from utils import load_tasks
 
 OBSIDIAN_VAULT = Path(os.getenv('OBSIDIAN_VAULT', Path.home() / "Obsidian"))
@@ -179,6 +180,7 @@ def generate_eod(target_date: datetime = None) -> dict:
         'done': done,
         'not_done': not_done,
         'tomorrows_top3': tomorrows_top3,
+        'completion_candidates': candidate_review_summary(),
         'source': source,
     }
 
@@ -215,6 +217,19 @@ def format_markdown(data: dict) -> str:
     else:
         lines.append('_No open Q1/Q2 items_')
 
+    candidates = data.get('completion_candidates') or {}
+    lines.extend(['', '## Completion Candidates'])
+    if candidates.get('review_required'):
+        lines.append(f"{candidates.get('total', 0)} candidate(s) need review.")
+        for candidate in candidates.get('items', [])[:5]:
+            task_hint = candidate.get('confirmable_task_id') or candidate.get('suggested_task_id')
+            suffix = f" -> {task_hint}" if task_hint else ""
+            lines.append(f"- {candidate.get('candidate_id')}: {candidate.get('summary')}{suffix}")
+        lines.append("")
+        lines.append("Review required; do not auto-complete from this summary.")
+    else:
+        lines.append('_No active completion candidates_')
+
     lines.extend([
         '',
         f"_Generated {datetime.now().isoformat()} via eod_review.py_",
@@ -247,6 +262,15 @@ def format_telegram(data: dict) -> str:
             lines.append(f"{i}. {item}")
     else:
         lines.append('- TBD')
+
+    candidates = data.get('completion_candidates') or {}
+    lines.extend(['', 'Completion candidates:'])
+    if candidates.get('review_required'):
+        lines.append(f"- {candidates.get('total', 0)} need review")
+        for candidate in candidates.get('items', [])[:3]:
+            lines.append(f"- {candidate.get('candidate_id')}: {candidate.get('summary')}")
+    else:
+        lines.append('- None')
 
     return '\n'.join(lines)
 

--- a/scripts/evidence_matching.py
+++ b/scripts/evidence_matching.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Shared completion-evidence parsing and task matching helpers."""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Any
+
+from task_records import active_records, record_to_task_dict, task_records as build_task_records
+from utils import get_tasks_file
+
+FUZZY_EVIDENCE_LINK_THRESHOLD = 0.90
+FUZZY_REVIEW_THRESHOLD = 0.70
+
+
+def safe_load_task_records(personal: bool = False) -> list:
+    tasks_file, fmt = get_tasks_file(personal)
+    if not tasks_file.exists():
+        return []
+    try:
+        content = tasks_file.read_text()
+    except OSError:
+        return []
+    try:
+        return build_task_records(content, personal=personal, fmt=fmt)
+    except Exception:
+        return []
+
+
+def normalize_title(title: str) -> str:
+    lowered = (title or "").strip().casefold()
+    lowered = re.sub(r"\[x\]|\[ \]|✅|☑️", " ", lowered)
+    lowered = re.sub(r"\*\*|__|~~", "", lowered)
+    lowered = re.sub(r"[^\w\s/-]", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered)
+    return lowered.strip()
+
+
+def extract_inline_identifiers(text: str) -> dict[str, set[str]]:
+    exact_identifiers: set[str] = set()
+    fallback_identifiers: set[str] = set()
+    if not text:
+        return {"exact": exact_identifiers, "fallback": fallback_identifiers}
+
+    for match in re.findall(
+        r"\b(?:id|task_id|task)::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        exact_identifiers.add(match.casefold())
+
+    for url in re.findall(r"https?://[^\s)>\]]+", text):
+        lowered_url = url.casefold()
+        exact_identifiers.add(lowered_url)
+        github_issue_match = re.search(
+            r"^https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)\b",
+            lowered_url,
+        )
+        if github_issue_match:
+            owner, repo, issue_num = github_issue_match.groups()
+            exact_identifiers.add(f"gh:{owner}/{repo}#{issue_num}")
+            fallback_identifiers.add(f"gh-issue-num:{issue_num}")
+
+    for match in re.findall(r"\b#(\d+)\b", text):
+        fallback_identifiers.add(f"gh-issue-num:{match}")
+
+    return {"exact": exact_identifiers, "fallback": fallback_identifiers}
+
+
+def record_identifier_bundle(record) -> dict[str, set[str]]:
+    raw_identifiers = extract_inline_identifiers(record.raw_line)
+    title_identifiers = extract_inline_identifiers(record.title)
+    exact_identifiers = raw_identifiers["exact"] | title_identifiers["exact"]
+    fallback_identifiers = raw_identifiers["fallback"] | title_identifiers["fallback"]
+    if record.canonical_id:
+        exact_identifiers.add(record.canonical_id.casefold())
+    return {
+        "exact_identifiers": exact_identifiers,
+        "fallback_identifiers": fallback_identifiers,
+    }
+
+
+def canonical_record(record) -> dict[str, Any]:
+    return record_to_task_dict(record)
+
+
+def extract_done_lines(content: str) -> list[dict[str, Any]]:
+    parsed: list[dict[str, Any]] = []
+    for line_number, raw in enumerate(content.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+
+        is_checkbox = bool(re.match(r"^\s*[-*+]\s+\[(?:x|X| )\]\s+", raw))
+        is_checked = bool(re.match(r"^\s*[-*+]\s+\[(?:x|X)\]\s+", raw))
+
+        is_plain_bullet = bool(re.match(r"^\s*[-*+]\s+", raw))
+        if is_checkbox and not is_checked:
+            continue
+        if not is_checkbox and not is_plain_bullet and not line.startswith("✅"):
+            pass
+
+        cleaned = re.sub(r"^\s*[-*+]\s+", "", raw).strip()
+        cleaned = re.sub(r"^\[(?:x|X| )\]\s+", "", cleaned)
+        cleaned = re.sub(r"^\d{1,2}:\d{2}(?::\d{2})?\s+", "", cleaned)
+        cleaned = re.sub(r"^✅\s*", "", cleaned)
+        cleaned = re.sub(r"\s*✅\s*\d{4}-\d{2}-\d{2}\s*$", "", cleaned)
+        cleaned = cleaned.strip()
+        if not cleaned:
+            continue
+
+        identifiers = extract_inline_identifiers(cleaned)
+        parsed.append(
+            {
+                "raw_line": raw.rstrip("\n"),
+                "line_number": line_number,
+                "title": cleaned,
+                "normalized_title": normalize_title(cleaned),
+                "exact_identifiers": identifiers["exact"],
+                "fallback_identifiers": identifiers["fallback"],
+            }
+        )
+    return parsed
+
+
+def fuzzy_score(left: str, right: str) -> float:
+    if not left or not right:
+        return 0.0
+    return SequenceMatcher(None, left, right).ratio()
+
+
+def build_task_catalog(records: list) -> list[dict[str, Any]]:
+    catalog: list[dict[str, Any]] = []
+    for record in active_records(records):
+        bundle = record_identifier_bundle(record)
+        canonical = canonical_record(record)
+        catalog.append(
+            {
+                "record": record,
+                "canonical": canonical,
+                "normalized_title": normalize_title(canonical["title"]),
+                "exact_identifiers": bundle["exact_identifiers"],
+                "fallback_identifiers": bundle["fallback_identifiers"],
+            }
+        )
+    return catalog
+
+
+def match_evidence_line(
+    line: dict[str, Any],
+    catalog: list[dict[str, Any]],
+    auto_threshold: float,
+    review_threshold: float,
+) -> dict[str, Any]:
+    def sort_key(candidate: dict[str, Any]) -> str:
+        canonical = candidate["canonical"]
+        return canonical.get("task_id") or canonical.get("fallback_id") or canonical.get("title") or ""
+
+    def result(
+        *,
+        candidate: dict[str, Any] | None,
+        score: float,
+        decision: str,
+        match_type: str,
+    ) -> dict[str, Any]:
+        return {
+            "raw_line": line["raw_line"],
+            "parsed_title": line["title"],
+            "normalized_title": line["normalized_title"],
+            "canonical_task": candidate["canonical"] if candidate and decision != "no-match" else None,
+            "match_metadata": {
+                "matched_task_id": (
+                    candidate["canonical"]["task_id"] if candidate and decision != "no-match" else None
+                ),
+                "score": round(float(score), 4),
+                "decision": decision,
+                "match_type": match_type,
+            },
+        }
+
+    exact_matches = [
+        candidate
+        for candidate in catalog
+        if line["exact_identifiers"] and (line["exact_identifiers"] & candidate["exact_identifiers"])
+    ]
+    if exact_matches:
+        chosen = sorted(exact_matches, key=sort_key)[0]
+        return result(
+            candidate=chosen,
+            score=1.0,
+            decision="evidence-link",
+            match_type="exact-id-or-link",
+        )
+
+    fallback_matches = [
+        candidate
+        for candidate in catalog
+        if line["fallback_identifiers"] and (line["fallback_identifiers"] & candidate["fallback_identifiers"])
+    ]
+    if fallback_matches:
+        chosen = sorted(fallback_matches, key=sort_key)[0]
+        return result(
+            candidate=chosen,
+            score=0.6,
+            decision="needs-review",
+            match_type="issue-number-fallback",
+        )
+
+    exact_title_matches = [
+        candidate for candidate in catalog if candidate["normalized_title"] == line["normalized_title"]
+    ]
+    if exact_title_matches:
+        chosen = sorted(exact_title_matches, key=sort_key)[0]
+        return result(
+            candidate=chosen,
+            score=1.0,
+            decision="evidence-link",
+            match_type="normalized-title",
+        )
+
+    scored = []
+    for candidate in catalog:
+        score = fuzzy_score(line["normalized_title"], candidate["normalized_title"])
+        scored.append((score, sort_key(candidate), candidate))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    best_score, _, best = scored[0] if scored else (0.0, "", None)
+
+    decision = "no-match"
+    if best and best_score >= auto_threshold:
+        decision = "evidence-link"
+    elif best and best_score >= review_threshold:
+        decision = "needs-review"
+
+    return result(candidate=best, score=best_score, decision=decision, match_type="fuzzy")
+
+
+def match_evidence_content(
+    content: str,
+    *,
+    personal: bool = False,
+    auto_threshold: float = FUZZY_EVIDENCE_LINK_THRESHOLD,
+    review_threshold: float = FUZZY_REVIEW_THRESHOLD,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    parsed = extract_done_lines(content)
+    records = safe_load_task_records(personal)
+    catalog = build_task_catalog(records)
+    matched = [
+        match_evidence_line(
+            line,
+            catalog,
+            auto_threshold=auto_threshold,
+            review_threshold=review_threshold,
+        )
+        for line in parsed
+    ]
+    for line, match in zip(parsed, matched, strict=False):
+        match["line_number"] = line.get("line_number")
+    return parsed, matched

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).parent))
+from candidate_review import candidate_review_summary
 from daily_notes import extract_completed_actions, extract_completed_tasks
 from standup_common import (
     flatten_calendar_events,
@@ -267,6 +268,7 @@ def build_compact_standup_sections(output: dict) -> dict:
         "calendar_dos": calendar_dos,
         "calendar_dones": calendar_dones,
         "dos": dos,
+        "completion_candidates": output.get("completion_candidates") or {},
         "links": _build_daily_note_links(output.get("date")),
     }
 
@@ -360,6 +362,7 @@ def generate_standup(
         output['completed'] = tasks_data.get('done', [])
 
     output['objective_progress'] = summarize_objective_progress(tasks_data)
+    output['completion_candidates'] = candidate_review_summary()
     
     if json_output:
         return output
@@ -459,6 +462,18 @@ def generate_standup(
             lines.append(f"  • {t['title']}{rec}")
         if len(output['completed']) > 5:
             lines.append(f"  • ... and {len(output['completed']) - 5} more")
+
+    candidates = output.get('completion_candidates') or {}
+    if candidates.get('review_required'):
+        lines.append("")
+        lines.append(f"🧾 **Completion Candidates:** {candidates.get('total', 0)} review required")
+        for candidate in candidates.get('items', [])[:3]:
+            task_hint = candidate.get('confirmable_task_id') or candidate.get('suggested_task_id')
+            suffix = f" → {task_hint}" if task_hint else ""
+            lines.append(f"  • {candidate.get('candidate_id')}: {candidate.get('summary')}{suffix}")
+        if candidates.get('overflow'):
+            lines.append(f"  • ... and {candidates['overflow']} more")
+        lines.append("  Review required; do not auto-complete from this summary.")
 
     objective_progress = output.get('objective_progress') or {}
     if objective_progress.get('total_objectives', 0) > 0:

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -17,13 +17,22 @@ import os
 import re
 import sys
 import uuid
-from difflib import SequenceMatcher
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).parent))
 from daily_notes import extract_completed_tasks
+from candidate_review import candidate_review_summary
+from evidence_matching import (
+    FUZZY_EVIDENCE_LINK_THRESHOLD,
+    FUZZY_REVIEW_THRESHOLD,
+    build_task_catalog,
+    canonical_record as _canonical_record,
+    extract_done_lines,
+    match_evidence_line,
+    safe_load_task_records as _safe_load_task_records,
+)
 from standup_common import get_calendar_events, flatten_calendar_events
 import delegation
 from task_identity import audit_payload, print_json as print_identity_json
@@ -33,7 +42,6 @@ from task_transitions import block_unsafe_query, complete_by_id, print_result
 from task_records import (
     active_records,
     record_to_task_dict,
-    task_records as build_task_records,
 )
 from utils import (
     detect_format,
@@ -48,8 +56,6 @@ from utils import (
 )
 
 TASK_PRIMITIVES_SCHEMA_VERSION = "v1"
-FUZZY_EVIDENCE_LINK_THRESHOLD = 0.90
-FUZZY_REVIEW_THRESHOLD = 0.70
 
 
 def list_tasks(args):
@@ -683,73 +689,6 @@ def _safe_load_tasks(personal: bool = False) -> dict:
         return empty
 
 
-def _safe_load_task_records(personal: bool = False) -> list:
-    tasks_file, fmt = get_tasks_file(personal)
-    if not tasks_file.exists():
-        return []
-    try:
-        content = tasks_file.read_text()
-    except OSError:
-        return []
-    try:
-        return build_task_records(content, personal=personal, fmt=fmt)
-    except Exception:
-        return []
-
-
-def _normalize_title(title: str) -> str:
-    lowered = (title or "").strip().casefold()
-    lowered = re.sub(r"\[x\]|\[ \]|✅|☑️", " ", lowered)
-    lowered = re.sub(r"\*\*|__|~~", "", lowered)
-    lowered = re.sub(r"[^\w\s/-]", " ", lowered)
-    lowered = re.sub(r"\s+", " ", lowered)
-    return lowered.strip()
-
-
-def _extract_inline_identifiers(text: str) -> dict[str, set[str]]:
-    exact_identifiers: set[str] = set()
-    fallback_identifiers: set[str] = set()
-    if not text:
-        return {"exact": exact_identifiers, "fallback": fallback_identifiers}
-
-    for match in re.findall(r"\b(?:id|task_id|task)::\s*([A-Za-z0-9._:-]*[A-Za-z0-9._-])(?=\s|$|[),.;!?])", text, flags=re.IGNORECASE):
-        exact_identifiers.add(match.casefold())
-
-    for url in re.findall(r"https?://[^\s)>\]]+", text):
-        lowered_url = url.casefold()
-        exact_identifiers.add(lowered_url)
-        github_issue_match = re.search(
-            r"^https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)\b",
-            lowered_url,
-        )
-        if github_issue_match:
-            owner, repo, issue_num = github_issue_match.groups()
-            exact_identifiers.add(f"gh:{owner}/{repo}#{issue_num}")
-            fallback_identifiers.add(f"gh-issue-num:{issue_num}")
-
-    for match in re.findall(r"\b#(\d+)\b", text):
-        fallback_identifiers.add(f"gh-issue-num:{match}")
-
-    return {"exact": exact_identifiers, "fallback": fallback_identifiers}
-
-
-def _record_identifier_bundle(record) -> dict:
-    raw_identifiers = _extract_inline_identifiers(record.raw_line)
-    title_identifiers = _extract_inline_identifiers(record.title)
-    exact_identifiers = raw_identifiers["exact"] | title_identifiers["exact"]
-    fallback_identifiers = raw_identifiers["fallback"] | title_identifiers["fallback"]
-    if record.canonical_id:
-        exact_identifiers.add(record.canonical_id.casefold())
-    return {
-        "exact_identifiers": exact_identifiers,
-        "fallback_identifiers": fallback_identifiers,
-    }
-
-
-def _canonical_record(record) -> dict:
-    return record_to_task_dict(record)
-
-
 def _group_tasks_by_area(tasks: list[dict]) -> dict[str, list[dict]]:
     grouped: dict[str, list[dict]] = {}
     for task in tasks:
@@ -800,164 +739,6 @@ def _parse_range_inputs(week: str | None, start_raw: str | None, end_raw: str | 
         raise ValueError("Invalid --week format. Use YYYY-WNN (example: 2026-W07).")
     start_date = date.fromisocalendar(int(match.group(1)), int(match.group(2)), 1)
     return start_date, start_date + timedelta(days=6), "iso-week"
-
-
-def _extract_done_lines(content: str) -> list[dict]:
-    parsed: list[dict] = []
-    for line_number, raw in enumerate(content.splitlines(), start=1):
-        line = raw.strip()
-        if not line:
-            continue
-
-        is_checkbox = bool(re.match(r"^\s*[-*+]\s+\[(?:x|X| )\]\s+", raw))
-        is_checked = bool(re.match(r"^\s*[-*+]\s+\[(?:x|X)\]\s+", raw))
-
-        is_plain_bullet = bool(re.match(r"^\s*[-*+]\s+", raw))
-        if is_checkbox and not is_checked:
-            continue
-        if not is_checkbox and not is_plain_bullet and not line.startswith("✅"):
-            # Plain lines are accepted as completed actions too.
-            pass
-
-        cleaned = re.sub(r"^\s*[-*+]\s+", "", raw).strip()
-        cleaned = re.sub(r"^\[(?:x|X| )\]\s+", "", cleaned)
-        cleaned = re.sub(r"^\d{1,2}:\d{2}(?::\d{2})?\s+", "", cleaned)
-        cleaned = re.sub(r"^✅\s*", "", cleaned)
-        cleaned = re.sub(r"\s*✅\s*\d{4}-\d{2}-\d{2}\s*$", "", cleaned)
-        cleaned = cleaned.strip()
-        if not cleaned:
-            continue
-
-        identifiers = _extract_inline_identifiers(cleaned)
-        parsed.append(
-            {
-                "raw_line": raw.rstrip("\n"),
-                "line_number": line_number,
-                "title": cleaned,
-                "normalized_title": _normalize_title(cleaned),
-                "exact_identifiers": identifiers["exact"],
-                "fallback_identifiers": identifiers["fallback"],
-            }
-        )
-    return parsed
-
-
-def _fuzzy_score(left: str, right: str) -> float:
-    if not left or not right:
-        return 0.0
-    return SequenceMatcher(None, left, right).ratio()
-
-
-def _build_task_catalog(records: list) -> list[dict]:
-    catalog: list[dict] = []
-    for record in records:
-        bundle = _record_identifier_bundle(record)
-        canonical = _canonical_record(record)
-        catalog.append(
-            {
-                "record": record,
-                "canonical": canonical,
-                "normalized_title": _normalize_title(canonical["title"]),
-                "exact_identifiers": bundle["exact_identifiers"],
-                "fallback_identifiers": bundle["fallback_identifiers"],
-            }
-        )
-    return catalog
-
-
-def _ingest_match_line(
-    line: dict,
-    catalog: list[dict],
-    auto_threshold: float,
-    review_threshold: float,
-) -> dict:
-    def _sort_key(candidate: dict) -> str:
-        canonical = candidate["canonical"]
-        return canonical.get("task_id") or canonical.get("fallback_id") or canonical.get("title") or ""
-
-    exact_matches = [
-        candidate
-        for candidate in catalog
-        if line["exact_identifiers"] and (line["exact_identifiers"] & candidate["exact_identifiers"])
-    ]
-    if exact_matches:
-        chosen = sorted(exact_matches, key=_sort_key)[0]
-        return {
-            "raw_line": line["raw_line"],
-            "parsed_title": line["title"],
-            "normalized_title": line["normalized_title"],
-            "canonical_task": chosen["canonical"],
-            "match_metadata": {
-                "matched_task_id": chosen["canonical"]["task_id"],
-                "score": 1.0,
-                "decision": "evidence-link",
-                "match_type": "exact-id-or-link",
-            },
-        }
-
-    fallback_matches = [
-        candidate
-        for candidate in catalog
-        if line["fallback_identifiers"] and (line["fallback_identifiers"] & candidate["fallback_identifiers"])
-    ]
-    if fallback_matches:
-        chosen = sorted(fallback_matches, key=_sort_key)[0]
-        return {
-            "raw_line": line["raw_line"],
-            "parsed_title": line["title"],
-            "normalized_title": line["normalized_title"],
-            "canonical_task": chosen["canonical"],
-            "match_metadata": {
-                "matched_task_id": chosen["canonical"]["task_id"],
-                "score": 0.6,
-                "decision": "needs-review",
-                "match_type": "issue-number-fallback",
-            },
-        }
-
-    exact_title_matches = [
-        candidate for candidate in catalog if candidate["normalized_title"] == line["normalized_title"]
-    ]
-    if exact_title_matches:
-        chosen = sorted(exact_title_matches, key=_sort_key)[0]
-        return {
-            "raw_line": line["raw_line"],
-            "parsed_title": line["title"],
-            "normalized_title": line["normalized_title"],
-            "canonical_task": chosen["canonical"],
-            "match_metadata": {
-                "matched_task_id": chosen["canonical"]["task_id"],
-                "score": 1.0,
-                "decision": "evidence-link",
-                "match_type": "normalized-title",
-            },
-        }
-
-    scored = []
-    for candidate in catalog:
-        score = _fuzzy_score(line["normalized_title"], candidate["normalized_title"])
-        scored.append((score, _sort_key(candidate), candidate))
-    scored.sort(key=lambda item: (-item[0], item[1]))
-    best_score, _, best = scored[0] if scored else (0.0, "", None)
-
-    decision = "no-match"
-    if best and best_score >= auto_threshold:
-        decision = "evidence-link"
-    elif best and best_score >= review_threshold:
-        decision = "needs-review"
-
-    return {
-        "raw_line": line["raw_line"],
-        "parsed_title": line["title"],
-        "normalized_title": line["normalized_title"],
-        "canonical_task": best["canonical"] if best and decision != "no-match" else None,
-        "match_metadata": {
-            "matched_task_id": best["canonical"]["task_id"] if best and decision != "no-match" else None,
-            "score": round(float(best_score), 4),
-            "decision": decision,
-            "match_type": "fuzzy",
-        },
-    }
 
 
 def cmd_standup_summary(args):
@@ -1030,6 +811,7 @@ def cmd_standup_summary(args):
             "dos": dos,
             "overdue": overdue,
             "carryover_suggestions": carryover_suggestions,
+            "completion_candidates": candidate_review_summary(personal=args.personal),
             "groups": {
                 "dones_by_area": _group_tasks_by_area(dones),
                 "dos_by_area": _group_tasks_by_area(dos),
@@ -1162,6 +944,7 @@ def cmd_weekly_review_summary(args):
                 "by_area": _group_tasks_by_area(do_items),
                 "by_category": _group_tasks_by_category(do_items),
             },
+            "completion_candidates": candidate_review_summary(personal=args.personal),
         }
     )
     print(json.dumps(payload, indent=2))
@@ -1190,9 +973,9 @@ def cmd_ingest_daily_log(args):
         source_content = sys.stdin.read()
         source = {"type": "stdin"}
 
-    parsed_lines = _extract_done_lines(source_content)
+    parsed_lines = extract_done_lines(source_content)
     records = _safe_load_task_records(args.personal)
-    catalog = _build_task_catalog(records)
+    catalog = build_task_catalog(records)
     auto_threshold = float(args.auto_threshold)
     review_threshold = float(args.review_threshold)
     if review_threshold > auto_threshold:
@@ -1200,7 +983,7 @@ def cmd_ingest_daily_log(args):
         sys.exit(2)
 
     matched = [
-        _ingest_match_line(line, catalog, auto_threshold=auto_threshold, review_threshold=review_threshold)
+        match_evidence_line(line, catalog, auto_threshold=auto_threshold, review_threshold=review_threshold)
         for line in parsed_lines
     ]
 

--- a/scripts/weekly_review.py
+++ b/scripts/weekly_review.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+from candidate_review import candidate_review_summary
 from daily_notes import extract_completed_actions, extract_completed_tasks
 from task_lines import remove_task_line
 from utils import (
@@ -322,6 +323,31 @@ def flatten_missed_buckets(missed_buckets: dict) -> list[dict]:
     return tasks
 
 
+def append_candidate_review_section(lines: list[str], limit: int = 5) -> None:
+    lines.append("")
+    lines.append("🧾 **Completion Candidates**")
+    summary = candidate_review_summary(limit=limit)
+    if not summary.get("available"):
+        error = summary.get("error") or {}
+        lines.append(f"  Review unavailable: {error.get('code', 'unknown-error')}.")
+        for item in (error.get("malformed") or [])[:3]:
+            lines.append(f"  • {item.get('path')}:{item.get('line_number')} {item.get('message')}")
+        return
+
+    if not summary.get("total"):
+        lines.append("  No active completion candidates.")
+        return
+
+    lines.append(f"  {summary.get('total', 0)} candidate(s) need review.")
+    for candidate in summary.get("items", []):
+        task_hint = candidate.get("confirmable_task_id") or candidate.get("suggested_task_id")
+        suffix = f" -> {task_hint}" if task_hint else ""
+        lines.append(f"  • {candidate.get('candidate_id')}: {candidate.get('summary')}{suffix}")
+    if summary.get("overflow"):
+        lines.append(f"  • ... and {summary['overflow']} more")
+    lines.append("  Review required; do not auto-complete from this summary.")
+
+
 def format_overdue(task: dict, reference_date: date) -> str:
     """Return overdue label for a task."""
     due_date = parse_due_date(task.get('due'))
@@ -495,6 +521,8 @@ def generate_weekly_review(week: str | None = None, archive: bool = False) -> st
         tasks_data, week_start, week_end, ARCHIVE_DIR, notes_dir=notes_dir,
     )
     lines.extend(velocity_lines)
+
+    append_candidate_review_section(lines)
 
     # Archive if requested
     if archive and done_tasks:

--- a/tests/test_completion_candidates.py
+++ b/tests/test_completion_candidates.py
@@ -118,6 +118,11 @@ def test_title_candidate_requires_explicit_task_id_before_confirmation(tmp_path)
     env = _env(tmp_path, work)
     scan = _scan_file(tmp_path, env, "- Ship alpha milestone\n")
     candidate_id = _candidate_id(scan)
+    candidate = scan["created"][0]
+
+    assert "confirmable_task_id" not in candidate
+    assert candidate["suggested_match"]["task_id"] == "tsk_ship"
+    assert candidate["review_required"] is True
 
     blocked = _run(["completion-candidates", "confirm", candidate_id], env)
     blocked_payload = _payload(blocked)
@@ -145,6 +150,10 @@ def test_exact_canonical_id_candidate_can_confirm_without_extra_task_id(tmp_path
     work = _write_work_file(tmp_path)
     env = _env(tmp_path, work)
     scan = _scan_file(tmp_path, env, "- Fixed login timeout task_id::tsk_login\n")
+    candidate = scan["created"][0]
+
+    assert candidate["confirmable_task_id"] == "tsk_login"
+    assert candidate["review_required"] is False
 
     proc = _run(["completion-candidates", "confirm", _candidate_id(scan)], env)
     payload = _payload(proc)
@@ -152,6 +161,48 @@ def test_exact_canonical_id_candidate_can_confirm_without_extra_task_id(tmp_path
     assert proc.returncode == 0
     assert payload["ok"] is True
     assert payload["candidate"]["status"] == "confirmed"
+    assert "Fix login timeout" not in work.read_text()
+
+
+def test_legacy_exact_candidate_projects_confirmable_task_id(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    candidate_id = "cand_legacy_exact"
+    legacy_event = {
+        "event_id": "evt_legacy",
+        "event_type": "candidate_seen",
+        "timestamp": "2026-05-21T00:00:00+00:00",
+        "actor": "task-tracker",
+        "source": "completion_candidate_scan",
+        "task_id": candidate_id,
+        "previous_state": None,
+        "next_state": None,
+        "reason": None,
+        "evidence": None,
+        "metadata": {
+            "candidate": {
+                "candidate_id": candidate_id,
+                "status": "new",
+                "source": {"type": "file", "path": "/tmp/legacy.md"},
+                "summary": "Fix login timeout task_id::tsk_login",
+                "matched_task_id": "tsk_login",
+                "match_metadata": {
+                    "matched_task_id": "tsk_login",
+                    "match_type": "exact-id-or-link",
+                    "decision": "evidence-link",
+                    "score": 1.0,
+                },
+            }
+        },
+    }
+    (tmp_path / "events.jsonl").write_text(json.dumps(legacy_event) + "\n")
+
+    shown = _payload(_run(["completion-candidates", "show", candidate_id], env))
+    confirmed = _run(["completion-candidates", "confirm", candidate_id], env)
+
+    assert shown["candidate"]["confirmable_task_id"] == "tsk_login"
+    assert shown["candidate"]["review_required"] is False
+    assert confirmed.returncode == 0
     assert "Fix login timeout" not in work.read_text()
 
 
@@ -166,6 +217,10 @@ def test_fallback_only_candidate_cannot_confirm_without_supplied_canonical_id(tm
     )
     env = _env(tmp_path, work)
     scan = _scan_file(tmp_path, env, "- Legacy title only\n")
+    candidate = scan["created"][0]
+
+    assert "confirmable_task_id" not in candidate
+    assert candidate["review_required"] is True
 
     proc = _run(["completion-candidates", "confirm", _candidate_id(scan)], env)
     payload = _payload(proc)
@@ -393,3 +448,87 @@ def test_scan_daily_note_uses_configured_notes_directory(tmp_path):
     assert proc.returncode == 0
     assert payload["totals"]["created"] == 1
     assert payload["created"][0]["source"]["type"] == "daily_note"
+
+
+def test_workflow_control_wrapper_delegates_candidate_decisions(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone\n")
+    candidate_id = _candidate_id(scan)
+
+    listed = subprocess.run(
+        ["python3", "scripts/completion_inbox_control.py", "list"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    blocked = subprocess.run(
+        ["python3", "scripts/completion_inbox_control.py", "confirm", candidate_id],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    confirmed = subprocess.run(
+        [
+            "python3",
+            "scripts/completion_inbox_control.py",
+            "confirm",
+            candidate_id,
+            "--task-id",
+            "tsk_ship",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert listed.returncode == 0
+    assert json.loads(listed.stdout)["total"] == 1
+    assert blocked.returncode == 2
+    assert json.loads(blocked.stdout)["error"]["code"] == "explicit-task-id-required"
+    assert confirmed.returncode == 0
+    assert json.loads(confirmed.stdout)["ok"] is True
+    assert "Ship alpha milestone" not in work.read_text()
+
+
+def test_standalone_workflow_scripts_surface_candidates_without_mutation(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    env["EOD_DAILY_DIR"] = str(tmp_path / "daily")
+    env["EOD_OUTPUT_DIR"] = str(tmp_path / "reports")
+    original = work.read_text()
+    scan = _scan_file(tmp_path, env, "- Ship alpha milestone\n")
+    candidate_id = _candidate_id(scan)
+
+    standup = subprocess.run(
+        ["python3", "scripts/standup.py", "--compact-json", "--skip-missed"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    eod = subprocess.run(
+        ["python3", "scripts/eod_review.py", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    weekly = subprocess.run(
+        ["python3", "scripts/weekly_review.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert standup.returncode == 0
+    assert eod.returncode == 0
+    assert weekly.returncode == 0
+    assert json.loads(standup.stdout)["completion_candidates"]["items"][0]["candidate_id"] == candidate_id
+    assert json.loads(eod.stdout)["completion_candidates"]["items"][0]["candidate_id"] == candidate_id
+    assert candidate_id in weekly.stdout
+    assert work.read_text() == original

--- a/tests/test_standup_compact.py
+++ b/tests/test_standup_compact.py
@@ -11,6 +11,7 @@ def test_compact_standup_sections(tmp_path):
     env = os.environ.copy()
     env["TASK_TRACKER_WORK_FILE"] = str(work)
     env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(tmp_path)
+    env["TASK_TRACKER_LEDGER_FILE"] = str(tmp_path / "events.jsonl")
     env["STANDUP_CALENDARS"] = "{}"
 
     proc = subprocess.run(
@@ -27,6 +28,7 @@ def test_compact_standup_sections(tmp_path):
     assert "calendar_dos" in payload
     assert "calendar_dones" in payload
     assert "dos" in payload
+    assert "completion_candidates" in payload
     assert "links" in payload
     assert payload["dos"]
     assert payload["calendar_dones"]

--- a/tests/test_task_primitives.py
+++ b/tests/test_task_primitives.py
@@ -24,6 +24,7 @@ def _env(tmp_path, work):
     env = os.environ.copy()
     env["TASK_TRACKER_WORK_FILE"] = str(work)
     env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(tmp_path)
+    env["TASK_TRACKER_LEDGER_FILE"] = str(tmp_path / "events.jsonl")
     env["STANDUP_CALENDARS"] = "{}"
     return env
 
@@ -76,6 +77,7 @@ def test_primitive_schema_shape(tmp_path):
     assert "dos" in standup_payload
     assert "overdue" in standup_payload
     assert "carryover_suggestions" in standup_payload
+    assert "completion_candidates" in standup_payload
 
     week_start = date.today() - timedelta(days=date.today().weekday())
     week_end = week_start + timedelta(days=6)
@@ -102,6 +104,7 @@ def test_primitive_schema_shape(tmp_path):
     assert "DO" in weekly_payload
     assert "by_area" in weekly_payload["DONE"]
     assert "by_category" in weekly_payload["DO"]
+    assert "completion_candidates" in weekly_payload
 
     cal = subprocess.run(
         ["python3", "scripts/tasks.py", "calendar-sync"],
@@ -143,6 +146,45 @@ def test_ingest_daily_log_plain_bullets_and_exact_matching(tmp_path):
     assert payload["items"][0]["match_metadata"]["decision"] == "evidence-link"
     assert payload["items"][0]["match_metadata"]["match_type"] in {"normalized-title", "exact-id-or-link"}
     assert payload["items"][1]["match_metadata"]["match_type"] == "exact-id-or-link"
+
+
+def test_primitive_summaries_include_completion_candidate_review_queue(tmp_path):
+    work = _write_work_file(tmp_path)
+    env = _env(tmp_path, work)
+    scan = subprocess.run(
+        ["python3", "scripts/tasks.py", "completion-candidates", "scan"],
+        input="- Ship alpha milestone\n",
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert scan.returncode == 0
+
+    standup = subprocess.run(
+        ["python3", "scripts/tasks.py", "standup-summary"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    weekly = subprocess.run(
+        ["python3", "scripts/tasks.py", "weekly-review-summary"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert standup.returncode == 0
+    assert weekly.returncode == 0
+    standup_candidates = json.loads(standup.stdout)["completion_candidates"]
+    weekly_candidates = json.loads(weekly.stdout)["completion_candidates"]
+    assert standup_candidates["total"] == 1
+    assert weekly_candidates["total"] == 1
+    assert standup_candidates["items"][0]["candidate_id"].startswith("cand_")
+    assert standup_candidates["items"][0]["suggested_task_id"] == "A-1"
+    assert standup_candidates["items"][0]["review_required"] is True
 
 
 def test_ingest_daily_log_checkbox_and_fuzzy_threshold_bands(tmp_path):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,6 +12,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'scripts'))
 
 import tasks
+from evidence_matching import extract_inline_identifiers
 
 
 def test_cmd_delegated_take_back_write_failure_keeps_delegated_item(tmp_path, monkeypatch):
@@ -96,7 +97,7 @@ def test_add_command_emits_canonical_task_id(tmp_path):
 
 
 def test_extract_inline_identifiers_accepts_trailing_punctuation():
-    identifiers = tasks._extract_inline_identifiers("Completed task_id::tsk_ship, and id::legacy-1)")
+    identifiers = extract_inline_identifiers("Completed task_id::tsk_ship, and id::legacy-1)")
 
     assert "tsk_ship" in identifiers["exact"]
     assert "legacy-1" in identifiers["exact"]


### PR DESCRIPTION
## Summary

This wires the completion evidence inbox into the daily workflow loop without expanding ingestion to Gmail, calendar, or session logs. Standup, EOD, weekly, and workflow-control surfaces can now show candidate counts/IDs and route decisions through the existing candidate confirmation path instead of inventing new DONE behavior.

[size/exempt: this intentionally includes the 108D plan artifact plus the matcher extraction and workflow surfaces needed for one coherent workflow-consumption slice]

## Design Notes

- Evidence matching now lives in `scripts/evidence_matching.py`, so candidate scanning and `ingest-daily-log` no longer import CLI-private helpers from `tasks.py`.
- Candidate JSON now distinguishes `confirmable_task_id` from `suggested_match`; only exact canonical ID/link evidence is directly confirmable without `--task-id`.
- `scripts/completion_inbox_control.py` gives Telegram/Lobster-style wrappers a stable list/show/reject/snooze/confirm control surface over the existing inbox.
- Standup, EOD, and weekly review output candidate review summaries but do not complete tasks from those summaries.

## Deferred

Gmail, calendar, and session-log evidence ingestion remain out of scope. Telegram/Lobster are control surfaces over existing candidates in this PR, not new evidence sources.

## Verification

- `python3 -m pytest -q` → 186 passed
- `python3 -m py_compile scripts/candidate_review.py scripts/evidence_matching.py scripts/completion_candidates.py scripts/completion_inbox_control.py scripts/tasks.py scripts/standup.py scripts/eod_review.py scripts/weekly_review.py`
- `bash scripts/ci/check-public-hygiene.sh`
- `markdownlint docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md README.md SKILL.md references/commands.md references/task-primitives-schema-v1.md`
- CLI help checks for candidate, done, inbox-control, standup, EOD, and weekly commands

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
