### PR TITLE
feat(tasks): add periodic task audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ python3 scripts/weekly_review.py
 - Canonical task identity audit/repair with inline `task_id::` metadata
 - Append-only JSONL event ledger for repairs and ID-based completions
 - Durable completion evidence inbox for review/confirm/reject/snooze decisions
+- Read-only task health audits for duplicate titles, stale tasks, identity
+  issues, candidates, and backlog pressure
 - Daily standup summaries (`standup.py`, `personal_standup.py`)
 - Weekly review + archive workflows (`weekly_review.py`, `archive.py`)
 - Backlog and delegated-task hygiene
@@ -63,6 +65,10 @@ and still require an explicit canonical `--task-id`. Standup, EOD, weekly, and
 workflow-control surfaces may show candidate counts and IDs, but they must not
 auto-complete tasks. Gmail, calendar, and session-log evidence ingestion remains
 deferred.
+
+Periodic task audits are also read-only. They surface task-health findings and
+safe next actions, but they do not freeze, delete, merge, complete, or otherwise
+mutate tasks.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -88,6 +88,7 @@ python3 scripts/tasks.py blockers
 python3 scripts/tasks.py add "Draft proposal" --priority high --due 2026-01-23
 python3 scripts/tasks.py --personal add "Call mom" --priority high --due 2026-01-22
 python3 scripts/tasks.py identity-audit
+python3 scripts/tasks.py task-audit
 python3 scripts/tasks.py identity-repair --apply
 python3 scripts/tasks.py done "tsk_example"
 python3 scripts/tasks.py --personal done "tsk_personal"
@@ -103,6 +104,10 @@ tasks; confirmation must resolve to a canonical `task_id::`. Workflow wrappers
 such as Telegram/Lobster should call `completion_inbox_control.py` or the
 `completion-candidates` command group by candidate ID. They must not call
 `done` by title, fuzzy match, fallback ID, quick ID, or list position.
+
+Task audits are read-only health checks. They can flag duplicate titles, stale
+active tasks, unresolved candidates, missing IDs, and backlog pressure, but they
+must not be treated as authority to freeze, delete, merge, or complete tasks.
 
 ### Backlog ops
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,6 +278,7 @@ sequenceDiagram
 | `done "task_id"` | | Complete exactly one active task by canonical ID |
 | `identity-audit` | | Report missing, duplicate, and malformed task IDs without writing |
 | `identity-repair` | `--apply` | Add safe missing `task_id::` metadata |
+| `task-audit` | `--stale-days`, `--candidate-days`, `--backlog-cap` | Report task-health findings without writing |
 | `ingest-daily-log` | `--file PATH` | Report completion evidence links; no task writes |
 | `completion-candidates scan` | `--file PATH`, `--date YYYY-MM-DD` | Persist completion evidence candidates; no task writes |
 | `completion-candidates list/show` | `--all`, `--mark-shown` | Review candidate inbox and event history |
@@ -346,6 +347,7 @@ sequenceDiagram
 | `tasks.py add` | Task board | Task board (insert line) |
 | `tasks.py done` | Task board, daily notes | Task board (remove/update line), daily note (append) |
 | `tasks.py identity-audit` | Task board | — |
+| `tasks.py task-audit` | Task board, ledger, parking lot | — |
 | `tasks.py ingest-daily-log` | Task board, done text | — |
 | `tasks.py completion-candidates scan` | Task board, done text, ledger | Ledger candidate events |
 | `tasks.py completion-candidates list/show` | Ledger | Ledger only with `--mark-shown` |

--- a/docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md
+++ b/docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md
@@ -103,6 +103,10 @@ post-108C follow-up notes in
 
 ### Deferred to Follow-Up Work
 
+- Periodic task audits for duplicate titles, stale active tasks, unresolved
+  candidates, identity issues, and backlog pressure. This became the next
+  automation layer before source ingestion; see
+  `docs/plans/2026-05-22-001-feat-periodic-task-audits-plan.md`.
 - Gmail evidence ingestion.
 - Calendar evidence ingestion.
 - Session-log evidence ingestion.

--- a/docs/plans/2026-05-22-001-feat-periodic-task-audits-plan.md
+++ b/docs/plans/2026-05-22-001-feat-periodic-task-audits-plan.md
@@ -1,0 +1,550 @@
+---
+title: "feat: Add periodic task audits"
+type: feat
+status: completed
+date: 2026-05-22
+origin: docs/solutions/workflow-issues/id-only-task-completion-source-of-truth-2026-05-22.md
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# feat: Add periodic task audits
+
+## Summary
+
+Add read-only periodic task audits that surface duplicate active tasks, missing
+or unsafe identities, stale active work, stale completion candidates, and backlog
+pressure without mutating the task board. The audit should become the next safe
+automation layer after the completion inbox: it tells the user and workflows
+what needs pruning, freezing, repairing, or review, while preserving canonical
+ID-only mutation rules.
+
+---
+
+## Problem Frame
+
+The task-tracker foundation now has canonical IDs, ID-only completion, shared
+task records, and a completion evidence inbox. The remaining daily pain is task
+buildup: duplicates, stale active items, unresolved candidates, and backlog
+items can accumulate silently until standup and weekly review become noisy again.
+
+The audit must not become another task system. It should report and recommend
+safe next actions; actual changes still happen through existing explicit
+commands such as identity repair, candidate decisions, and canonical ID-based
+task transitions.
+
+---
+
+## Requirements
+
+- R1. Provide a `task-audit` primitive that produces deterministic JSON for work
+  and personal boards.
+- R2. Audit output must include duplicate-title clusters, missing or malformed
+  canonical IDs, stale active tasks, overdue tasks, stale completion candidates,
+  and backlog or parking-lot pressure.
+- R3. Audit output must include concise human-readable summaries suitable for
+  standup, EOD, weekly review, and Lobster/OpenClaw cron relay surfaces.
+- R4. Audits must be read-only by default and must not mutate the active board,
+  daily notes, completion log, or ledger.
+- R5. Audit recommendations must name safe existing commands or candidate IDs,
+  not title/fuzzy/list-position mutation paths.
+- R6. Duplicate detection must treat duplicate titles as review signals, not as
+  evidence that tasks are identical or safe to merge.
+- R7. Staleness must be explainable: each flagged task should show the basis for
+  the age calculation and whether the signal came from task metadata, due date,
+  candidate history, or backlog metadata.
+- R8. Workflow surfaces must cap audit output and link to or name the full audit
+  command when there is overflow.
+- R9. The first slice must not add automatic freezing, deletion, merging,
+  bulk-confirming, Gmail ingestion, calendar ingestion, or session-log evidence
+  ingestion.
+
+---
+
+## Scope Boundaries
+
+- The audit is advisory. It can recommend repair, review, freeze, backlog, or
+  candidate decisions, but it must not perform those actions.
+- The audit should rely on existing local data: active boards, task records,
+  identity audit results, candidate ledger projection, and parking-lot metadata.
+- The audit should support work and personal modes without collapsing their
+  board or ledger state.
+- The audit should not introduce a new persistent audit database in this slice.
+
+### Deferred to Follow-Up Work
+
+- Automatic freeze/backlog/delete/merge actions: future explicit workflow after
+  audit recommendations prove useful.
+- Session-log extraction into completion candidates: separate ingestion PR after
+  audits are visible in daily usage.
+- Gmail and calendar evidence ingestion: later source-adapter PRs after local
+  audit and candidate loops are reliable.
+- A full daily/weekly recap redesign: future UX PR that can consume the audit
+  summary once the primitive exists.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/task_records.py` provides the shared `TaskRecord` model, canonical
+  identity fields, fallback diagnostics, active-record filtering, and line
+  numbers.
+- `scripts/task_identity.py` already reports missing, duplicate, and malformed
+  task IDs without writing.
+- `scripts/candidate_review.py` provides capped read-only completion candidate
+  summaries for workflow surfaces.
+- `scripts/completion_candidates.py` projects candidate state from the JSONL
+  ledger using strict ledger reads.
+- `scripts/parking_lot.py` already exposes stale backlog item parsing and JSON
+  output.
+- `scripts/tasks.py` owns the stable primitive envelope pattern used by
+  `standup-summary`, `weekly-review-summary`, `calendar-sync`, and
+  `completion-candidates`.
+- `scripts/standup.py`, `scripts/eod_review.py`, and `scripts/weekly_review.py`
+  already display completion candidate review pointers without completing tasks.
+- `tests/test_task_primitives.py`, `tests/test_completion_candidates.py`,
+  `tests/test_task_identity.py`, and `tests/test_parking_lot.py` cover the
+  safest existing patterns for this work.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/id-only-task-completion-source-of-truth-2026-05-22.md`
+  establishes the source-of-truth boundary: active boards own current state,
+  daily/weekly notes are logs or evidence, and the ledger is audit/candidate
+  history.
+- The same solution note requires wrappers to remain thin and forbids completion
+  from title, fuzzy match, fallback ID, quick ID, list position, calendar, Gmail,
+  or session evidence.
+- `docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md` shows the
+  pattern for adding workflow-visible summaries without adding noisy ingestion
+  sources.
+
+### External References
+
+- None. The codebase already has the relevant primitives and safety pattern; the
+  main risk is preserving local source-of-truth semantics, not adopting a new
+  external framework.
+
+---
+
+## Key Technical Decisions
+
+- **Make the audit a primitive, not a workflow script.** `tasks.py task-audit`
+  should be the stable contract; standup, weekly, EOD, Telegram, and Lobster can
+  consume it without reimplementing task semantics.
+- **Keep audit rows action-oriented but read-only.** Each finding should include
+  `severity`, `reason`, `task_id` when safe, `fallback_id` only as diagnostic,
+  and `recommended_action` text that points at safe commands.
+- **Use severity bands instead of automatic mutation.** For example, missing IDs
+  and malformed ledgers can be blocking/high, duplicate titles and stale tasks
+  can be review/high or review/medium, and backlog pressure can be warning/low.
+- **Compute stale status from explicit evidence only.** Due dates, task metadata,
+  candidate timestamps, and backlog stale markers are acceptable. When no
+  touched/created metadata exists, mark the basis as unavailable instead of
+  inventing an age.
+- **Cap workflow summaries.** Daily surfaces should show counts and the top few
+  actionable findings, not dump the full audit.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the audit mutate tasks? No. This slice is read-only by default and
+  should only recommend existing safe commands.
+- Should Gmail, calendar, or session sources be included? No. Those remain
+  deferred until local audit and candidate-review behavior is proven.
+- Should duplicates be merged automatically? No. Duplicate titles are ambiguous
+  and must be treated as review prompts.
+
+### Deferred to Implementation
+
+- Exact default thresholds for stale active tasks and backlog pressure: choose
+  conservative defaults after inspecting current local constants and tests, and
+  expose CLI flags or env overrides if they fit existing command style.
+- Exact human summary wording: keep it concise and verify with markdown/text
+  fixtures; final phrasing can be adjusted during implementation.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  Board[Active board markdown] --> Records[TaskRecord catalog]
+  Records --> Identity[identity audit]
+  Records --> ActiveStale[stale active task audit]
+  Records --> DuplicateTitles[duplicate title audit]
+  Records --> Overdue[overdue audit]
+  Ledger[JSONL ledger] --> Candidates[candidate projection]
+  Backlog[Parking Lot section] --> BacklogAudit[backlog pressure audit]
+  Identity --> Audit[task-audit primitive]
+  ActiveStale --> Audit
+  DuplicateTitles --> Audit
+  Overdue --> Audit
+  Candidates --> Audit
+  BacklogAudit --> Audit
+  Audit --> Json[JSON output]
+  Audit --> Summary[bounded text summary]
+  Summary --> Standup[standup/EOD/weekly/Lobster surfaces]
+```
+
+---
+
+## Implementation Units
+
+### U1. Audit Data Model and Collector
+
+**Goal:** Add a read-only audit module that collects findings from existing task
+records, identity audit data, candidate projection, and parking-lot metadata.
+
+**Requirements:** R1, R2, R4, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `scripts/task_audit.py`
+- Modify: `scripts/task_records.py`
+- Test: `tests/test_task_audit.py`
+
+**Approach:**
+
+- Define a small audit result shape with top-level totals, `findings`, and
+  `summary`.
+- Load `TaskRecord` data using the shared record helpers.
+- Reuse `task_identity.audit_payload()` for missing, duplicate, and malformed
+  identity signals instead of creating a second identity scanner.
+- Group duplicate active task titles by normalized title, but mark them as
+  review-only findings.
+- Detect overdue tasks from existing due-date data and stale active tasks from
+  due date or explicit metadata only.
+- Project completion candidates using the existing candidate review/projection
+  path and report unresolved, snoozed-expired, and apply-failed candidates.
+- Read parking-lot stale data through the existing parking-lot parser or a
+  shared helper extracted from it if needed.
+
+**Execution note:** Start characterization-first around current parser and
+parking-lot behavior before adding new audit classifications.
+
+**Patterns to follow:**
+
+- `scripts/candidate_review.py` for read-only workflow-safe summaries.
+- `scripts/task_identity.py` for identity diagnostics and blocking labels.
+- `scripts/task_records.py` for canonical task row shape and fallback-only
+  diagnostics.
+
+**Test scenarios:**
+
+- Happy path: board with unique canonical IDs and no stale/candidate/backlog
+  issues returns `ok: true`, zero high findings, and stable totals.
+- Happy path: duplicate active titles with different task IDs produce one
+  duplicate-title finding listing both canonical task IDs.
+- Edge case: duplicate title where one task has only a fallback ID reports the
+  fallback as diagnostic and does not recommend merge or completion.
+- Edge case: task missing `task_id::` is reported via the identity audit path
+  with `identity-repair --dry-run` as the recommended safe action.
+- Edge case: overdue task with canonical ID appears in overdue findings without
+  mutating the board.
+- Error path: malformed candidate ledger returns an audit finding or degraded
+  section instead of silently dropping candidate history.
+- Integration: personal mode reads the personal board and personal ledger only.
+
+**Verification:**
+
+- The audit module can be imported without side effects.
+- Tests prove audit collection does not change board, daily note, or ledger
+  contents.
+
+### U2. CLI Primitive and JSON Contract
+
+**Goal:** Expose the audit through a stable `tasks.py task-audit` primitive with
+JSON output and threshold controls.
+
+**Requirements:** R1, R2, R4, R5, R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `scripts/tasks.py`
+- Modify: `references/task-primitives-schema-v1.md`
+- Modify: `references/commands.md`
+- Test: `tests/test_task_primitives.py`
+- Test: `tests/test_task_audit.py`
+
+**Approach:**
+
+- Add `task-audit` to the existing primitive envelope style:
+  `schema_version`, `command`, `generated_at`, `personal`, `totals`,
+  `findings`, and `summary`.
+- Support `--json` or make JSON the default if that matches nearby primitives;
+  preserve a concise text mode only if it follows existing CLI conventions.
+- Add threshold flags such as `--stale-days`, `--candidate-days`, and
+  `--backlog-cap` only where they map to existing local concepts.
+- Ensure every finding with a mutation recommendation names a safe explicit
+  command and never a title/fuzzy/list-position action.
+- Return structured degraded output for unavailable optional surfaces.
+
+**Patterns to follow:**
+
+- `cmd_standup_summary()` and `cmd_weekly_review_summary()` in `scripts/tasks.py`
+  for primitive envelopes.
+- `references/task-primitives-schema-v1.md` for documenting command JSON.
+
+**Test scenarios:**
+
+- Happy path: `tasks.py task-audit` returns `schema_version: v1` and
+  `command: task-audit`.
+- Happy path: `--personal task-audit` uses the personal task file and does not
+  read or write the work ledger.
+- Edge case: threshold flags change stale classification without changing task
+  contents.
+- Error path: malformed ledger exits or reports with the same strictness used by
+  completion candidate commands.
+- Integration: `task-audit` output includes identity, duplicate, candidate, and
+  backlog sections when fixtures contain all four.
+
+**Verification:**
+
+- CLI help describes the audit as read-only.
+- JSON shape is documented and covered by tests.
+
+### U3. Human Summary for Daily and Weekly Surfaces
+
+**Goal:** Add capped audit summaries to standup, EOD, and weekly review outputs
+so the user sees task buildup before it becomes painful.
+
+**Requirements:** R3, R5, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `scripts/standup.py`
+- Modify: `scripts/eod_review.py`
+- Modify: `scripts/weekly_review.py`
+- Modify: `scripts/tasks.py`
+- Test: `tests/test_standup_compact.py`
+- Test: `tests/test_task_primitives.py`
+- Test: `tests/test_weekly_review.py`
+
+**Approach:**
+
+- Add a compact audit section that shows counts and top findings by severity.
+- Include candidate IDs and canonical task IDs where available.
+- Use explicit review language such as "review required" or "repair suggested";
+  do not phrase findings as completed work.
+- Cap daily output more aggressively than weekly output.
+- Keep any marker such as `--mark-shown` limited to completion candidates; audit
+  display should not create audit events in this slice.
+
+**Patterns to follow:**
+
+- Existing completion candidate sections in `scripts/standup.py` and
+  `scripts/weekly_review.py`.
+- `candidate_review_summary()` output style for capped review queues.
+
+**Test scenarios:**
+
+- Happy path: standup summary includes audit totals and top finding IDs without
+  changing board or ledger files.
+- Happy path: weekly review includes a broader audit pointer but does not call
+  archive cleanup or candidate confirmation.
+- Edge case: no findings produces a short quiet state instead of a noisy empty
+  section.
+- Edge case: many findings show overflow count and full command pointer.
+- Error path: malformed ledger renders a degraded audit warning rather than
+  implying there are no candidate issues.
+
+**Verification:**
+
+- Daily and weekly text remains concise.
+- Read-only rendering leaves board, daily notes, and ledger unchanged.
+
+### U4. Lobster/OpenClaw Cron Consumption
+
+**Goal:** Let existing Lobster/OpenClaw workflows relay periodic audit summaries
+without implementing task semantics outside task-tracker.
+
+**Requirements:** R3, R4, R5, R8
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `references/commands.md`
+- Modify: `docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md`
+- Test: `tests/test_task_primitives.py`
+
+**Approach:**
+
+- Document the workflow contract for external consumers: call the audit
+  primitive, display summary, and route actions through existing explicit
+  commands.
+- Keep repo-specific cron wiring out of this task-tracker PR unless the
+  implementation needs a tiny command wrapper. Lobster-specific schedule changes
+  should land in the workflow repo.
+- Specify likely cadence in docs: daily lightweight audit in EOD or standup, and
+  weekly broader audit during weekly review.
+- Make clear that cron jobs must not auto-freeze, auto-delete, auto-merge, or
+  auto-confirm from audit output.
+
+**Patterns to follow:**
+
+- `docs/ARCHITECTURE.md` read/write table for command side effects.
+- `SKILL.md` command examples and safety contract.
+- Prior workflow-consumption plan language around Lobster and Telegram wrappers.
+
+**Test scenarios:**
+
+- Documentation examples invoke `task-audit` and safe follow-up commands only.
+- Existing primitive summary tests prove external workflows can consume JSON
+  without needing markdown parsing.
+
+**Verification:**
+
+- Docs make the audit cadence and safety boundary clear enough for workflow
+  agents.
+
+### U5. Regression and Safety Suite
+
+**Goal:** Prove the audit cannot reopen the title/fuzzy/fallback mutation risks
+closed by the prior vNext work.
+
+**Requirements:** R4, R5, R6, R9
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+
+- Modify: `tests/test_task_audit.py`
+- Modify: `tests/test_task_primitives.py`
+- Modify: `tests/test_completion_candidates.py`
+- Modify: `tests/test_task_identity.py`
+- Modify: `tests/test_parking_lot.py`
+
+**Approach:**
+
+- Add fixture-backed tests around mixed unsafe conditions: duplicate title,
+  missing ID, fallback-only task, stale candidate, and backlog pressure.
+- Snapshot before and after audit commands to prove no unintended writes.
+- Include explicit negative assertions that audit output does not expose title,
+  fuzzy, fallback, quick ID, local numeric ID, or list position as mutation
+  targets.
+- Preserve work/personal isolation tests.
+
+**Patterns to follow:**
+
+- Existing before/after mutation assertions in `tests/test_completion_candidates.py`.
+- Existing duplicate-title primitive tests in `tests/test_task_primitives.py`.
+
+**Test scenarios:**
+
+- Integration: running `task-audit`, standup, EOD, and weekly summary on the same
+  fixture causes no board, daily-note, or ledger mutation.
+- Error path: malformed ledger blocks or degrades audit candidate reporting
+  without hiding the identity and duplicate findings that can still be computed.
+- Edge case: duplicate title cluster with one canonical ID and one fallback-only
+  row is review-only and not mergeable.
+- Edge case: stale snoozed candidate appears actionable again without changing
+  candidate status.
+- Error path: audit recommendations never include `tasks.py done "title"` or
+  any local numeric parking-lot ID as a canonical mutation path.
+
+**Verification:**
+
+- Focused audit, primitive, identity, candidate, and parking-lot tests pass.
+- Public hygiene and markdownlint pass for changed docs.
+
+---
+
+## System-Wide Impact
+
+- **Daily workflow:** Standup/EOD can show small task-health warnings before the
+  board becomes unmanageable.
+- **Weekly review:** Weekly output can separate "work completed" from "task
+  system cleanup needed."
+- **Agent safety:** Agents get explicit audit findings and safe repair/review
+  actions instead of inferring from titles or stale checked boxes.
+- **Workflow integration:** Lobster/OpenClaw can relay audit summaries without
+  owning task parsing or task mutation.
+- **State lifecycle risks:** The audit introduces no new active state; it reads
+  board, ledger, and backlog state and emits findings.
+- **Unchanged invariants:** Active board markdown remains current task state;
+  daily/weekly notes remain logs; ledger remains audit/candidate history; task
+  completion remains ID-only.
+
+---
+
+## Risks & Dependencies
+
+- Audit becomes another task system: keep it read-only and avoid any new
+  persistent audit database in this slice.
+- Stale logic invents false certainty: include `basis` fields and mark
+  unavailable age data explicitly.
+- Duplicate detection encourages unsafe merges: treat duplicate titles as
+  review-only and never as merge authority.
+- Daily summaries become noisy: cap output and put full detail behind
+  `task-audit`.
+- Workflow scripts bypass command contract: document and test that consumers
+  call `task-audit` and existing explicit commands only.
+- Work/personal data leaks across modes: reuse existing `--personal` patterns
+  and add isolation tests.
+
+---
+
+## Phased Delivery
+
+1. Build the read-only audit collector and tests.
+2. Expose the `task-audit` primitive and schema docs.
+3. Add capped standup/EOD/weekly audit summaries.
+4. Update docs for Lobster/OpenClaw cron consumption and safe cadence.
+5. Expand regression tests around no mutation, duplicate titles, fallback-only
+   IDs, malformed ledger, and work/personal isolation.
+
+---
+
+## Documentation Plan
+
+- Update `README.md`, `SKILL.md`, and `references/commands.md` with `task-audit`
+  usage and the read-only contract.
+- Update `references/task-primitives-schema-v1.md` with the audit JSON shape.
+- Update `docs/ARCHITECTURE.md` with audit read/write behavior.
+- Update the prior workflow-consumption plan to note that periodic audits are
+  the next automation layer before source ingestion.
+
+---
+
+## Verification Strategy
+
+- Focused tests for `tests/test_task_audit.py`.
+- Primitive regression tests in `tests/test_task_primitives.py`.
+- Candidate and identity regression coverage where audit consumes those
+  surfaces.
+- Standup, EOD, and weekly summary checks proving capped audit visibility and no
+  mutation.
+- Public hygiene, markdownlint, and CLI help checks for the new command.
+
+---
+
+## Sources & References
+
+- `docs/solutions/workflow-issues/id-only-task-completion-source-of-truth-2026-05-22.md`
+- `docs/plans/2026-05-20-001-refactor-pr108-identity-kernel-split-plan.md`
+- `docs/plans/2026-05-21-003-feat-completion-evidence-inbox-plan.md`
+- `docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md`
+- `docs/ARCHITECTURE.md`
+- `references/task-primitives-schema-v1.md`
+- `references/commands.md`
+- `SKILL.md`

--- a/references/commands.md
+++ b/references/commands.md
@@ -32,6 +32,7 @@ python3 scripts/tasks.py blockers --person sarah
 python3 scripts/tasks.py add "Draft project proposal" --priority high --due 2026-01-23
 python3 scripts/tasks.py --personal add "Call mom" --priority high --due 2026-01-22
 python3 scripts/tasks.py identity-audit
+python3 scripts/tasks.py task-audit
 python3 scripts/tasks.py identity-repair
 python3 scripts/tasks.py identity-repair --apply
 python3 scripts/tasks.py done "tsk_example"
@@ -68,6 +69,7 @@ python3 scripts/tasks.py calendar resolve --window today --json
 python3 scripts/tasks.py standup-summary
 python3 scripts/tasks.py weekly-review-summary --week 2026-W08
 python3 scripts/tasks.py weekly-review-summary --start 2026-02-16 --end 2026-02-22
+python3 scripts/tasks.py task-audit --stale-days 14 --candidate-days 7
 python3 scripts/tasks.py ingest-daily-log --file /tmp/done-log.md
 cat /tmp/done-log.md | python3 scripts/tasks.py ingest-daily-log
 python3 scripts/tasks.py calendar-sync
@@ -83,6 +85,11 @@ All primitives return JSON with a stable envelope:
 ```
 
 Detailed shape: `references/task-primitives-schema-v1.md`.
+
+`task-audit` is read-only. It reports duplicate titles, identity issues,
+overdue/stale active tasks, stale candidates, and backlog pressure. Follow-up
+actions must use explicit repair, candidate, backlog, or canonical task-ID
+commands.
 
 ### Completion evidence inbox
 

--- a/references/task-primitives-schema-v1.md
+++ b/references/task-primitives-schema-v1.md
@@ -144,6 +144,76 @@ Optional helper command. It must not hard-fail if calendar/task sources are unav
 }
 ```
 
+## `task-audit`
+
+Read-only task-health primitive for periodic standup, EOD, weekly, and workflow
+surfaces. It reports findings and recommended safe actions, but does not write
+the board, daily notes, completion log, or ledger.
+
+```json
+{
+  "schema_version": "v1",
+  "command": "task-audit",
+  "ok": false,
+  "personal": false,
+  "generated_at": "2026-05-22T10:00:00",
+  "thresholds": {
+    "stale_days": 14,
+    "candidate_days": 7,
+    "backlog_cap": 25
+  },
+  "totals": {
+    "active_tasks": 10,
+    "findings": 2,
+    "high": 1,
+    "medium": 1,
+    "low": 0
+  },
+  "findings": [
+    {
+      "code": "duplicate-title",
+      "severity": "medium",
+      "reason": "Multiple active tasks have the same title.",
+      "basis": {
+        "source": "task-records",
+        "match": "normalized-title"
+      },
+      "recommended_action": "Review canonical task IDs; do not complete by title.",
+      "tasks": [
+        {
+          "task_id": "tsk_one",
+          "fallback_id": "fallback_example",
+          "fallback_only": false,
+          "title": "Draft proposal",
+          "section": "q1",
+          "area": "Sales",
+          "line_number": 4
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "review_required": true,
+    "total": 2,
+    "by_severity": {
+      "high": 1,
+      "medium": 1
+    },
+    "items": [],
+    "overflow": 0,
+    "instructions": "Review findings; mutate only through task_id:: commands."
+  }
+}
+```
+
+Finding codes may include `missing-task-id`, `malformed-task-id`,
+`duplicate-task-id`, `duplicate-title`, `overdue-task`, `stale-active-task`,
+`stale-completion-candidate`, `candidate-snooze-expired`,
+`candidate-apply-failed`, `stale-backlog-item`, and `backlog-cap-reached`.
+Findings are advisory and must not be applied from title, fuzzy match, fallback
+ID, quick ID, local numeric ID, calendar event, Gmail message, session note, or
+list position.
+
 ## `completion-candidates`
 
 The completion evidence inbox stores candidate lifecycle events in the JSONL

--- a/scripts/eod_review.py
+++ b/scripts/eod_review.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from pathlib import Path
 
 from candidate_review import candidate_review_summary
+from task_audit import task_audit_summary
 from utils import load_tasks
 
 OBSIDIAN_VAULT = Path(os.getenv('OBSIDIAN_VAULT', Path.home() / "Obsidian"))
@@ -181,6 +182,7 @@ def generate_eod(target_date: datetime = None) -> dict:
         'not_done': not_done,
         'tomorrows_top3': tomorrows_top3,
         'completion_candidates': candidate_review_summary(),
+        'task_audit': task_audit_summary(limit=3),
         'source': source,
     }
 
@@ -230,6 +232,19 @@ def format_markdown(data: dict) -> str:
     else:
         lines.append('_No active completion candidates_')
 
+    audit = data.get('task_audit') or {}
+    lines.extend(['', '## Task Audit'])
+    if audit.get('review_required'):
+        lines.append(f"{audit.get('total', 0)} task-health finding(s) need review.")
+        for finding in audit.get('items', [])[:3]:
+            lines.append(f"- {finding.get('severity')}: {finding.get('code')} — {finding.get('reason')}")
+        if audit.get('overflow'):
+            lines.append(f"- ... and {audit['overflow']} more")
+        lines.append("")
+        lines.append("Run `tasks.py task-audit`; do not mutate from audit text.")
+    else:
+        lines.append('_No task-health findings_')
+
     lines.extend([
         '',
         f"_Generated {datetime.now().isoformat()} via eod_review.py_",
@@ -269,6 +284,15 @@ def format_telegram(data: dict) -> str:
         lines.append(f"- {candidates.get('total', 0)} need review")
         for candidate in candidates.get('items', [])[:3]:
             lines.append(f"- {candidate.get('candidate_id')}: {candidate.get('summary')}")
+    else:
+        lines.append('- None')
+
+    audit = data.get('task_audit') or {}
+    lines.extend(['', 'Task audit:'])
+    if audit.get('review_required'):
+        lines.append(f"- {audit.get('total', 0)} need review")
+        for finding in audit.get('items', [])[:3]:
+            lines.append(f"- {finding.get('severity')}: {finding.get('code')}")
     else:
         lines.append('- None')
 

--- a/scripts/eod_review.py
+++ b/scripts/eod_review.py
@@ -234,7 +234,10 @@ def format_markdown(data: dict) -> str:
 
     audit = data.get('task_audit') or {}
     lines.extend(['', '## Task Audit'])
-    if audit.get('review_required'):
+    if audit.get('review_required') and not audit.get('available', True):
+        error = audit.get('error') or {}
+        lines.append(f"Audit unavailable: {error.get('code', 'unknown-error')}.")
+    elif audit.get('review_required'):
         lines.append(f"{audit.get('total', 0)} task-health finding(s) need review.")
         for finding in audit.get('items', [])[:3]:
             lines.append(f"- {finding.get('severity')}: {finding.get('code')} — {finding.get('reason')}")
@@ -289,7 +292,10 @@ def format_telegram(data: dict) -> str:
 
     audit = data.get('task_audit') or {}
     lines.extend(['', 'Task audit:'])
-    if audit.get('review_required'):
+    if audit.get('review_required') and not audit.get('available', True):
+        error = audit.get('error') or {}
+        lines.append(f"- Unavailable: {error.get('code', 'unknown-error')}")
+    elif audit.get('review_required'):
         lines.append(f"- {audit.get('total', 0)} need review")
         for finding in audit.get('items', [])[:3]:
             lines.append(f"- {finding.get('severity')}: {finding.get('code')}")

--- a/scripts/parking_lot.py
+++ b/scripts/parking_lot.py
@@ -219,6 +219,51 @@ def list_stale(tasks_file: Path) -> str:
     return json.dumps(stale, indent=2)
 
 
+def audit_items(tasks_file: Path, *, cap: int | None = None) -> dict:
+    """Return read-only Parking Lot audit data."""
+    content = tasks_file.read_text()
+    lines = content.split('\n')
+    start, end = _find_parking_lot_bounds(lines)
+    effective_cap = cap if cap is not None else _parking_lot_cap()
+    if start == -1:
+        return {
+            'available': False,
+            'cap': effective_cap,
+            'total': 0,
+            'stale_count': 0,
+            'items': [],
+            'stale': [],
+        }
+
+    items = _parse_items(lines, start, end)
+    stale = []
+    exported = []
+    for it in items:
+        age_days = _days_since(it.get('created'))
+        row = {
+            'id': it['id'],
+            'title': it['title'],
+            'department': it.get('department'),
+            'priority': it.get('priority'),
+            'created': it.get('created'),
+            'age_days': age_days,
+            'line_number': (it.get('line_num') or 0) + 1,
+            'raw_line': it.get('raw_line'),
+        }
+        exported.append(row)
+        if _is_stale(it):
+            stale.append(row)
+
+    return {
+        'available': True,
+        'cap': effective_cap,
+        'total': len(items),
+        'stale_count': len(stale),
+        'items': exported,
+        'stale': stale,
+    }
+
+
 def add_item(tasks_file: Path, title: str, dept: str | None = None,
              priority: str = 'low', task_id: str | None = None) -> str:
     """Add an item to the parking lot. Returns status message."""

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -13,6 +13,7 @@ from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).parent))
 from candidate_review import candidate_review_summary
+from task_audit import task_audit_summary
 from daily_notes import extract_completed_actions, extract_completed_tasks
 from standup_common import (
     flatten_calendar_events,
@@ -363,6 +364,7 @@ def generate_standup(
 
     output['objective_progress'] = summarize_objective_progress(tasks_data)
     output['completion_candidates'] = candidate_review_summary()
+    output['task_audit'] = task_audit_summary(limit=3)
     
     if json_output:
         return output
@@ -474,6 +476,16 @@ def generate_standup(
         if candidates.get('overflow'):
             lines.append(f"  • ... and {candidates['overflow']} more")
         lines.append("  Review required; do not auto-complete from this summary.")
+
+    audit = output.get('task_audit') or {}
+    if audit.get('review_required'):
+        lines.append("")
+        lines.append(f"🧹 **Task Audit:** {audit.get('total', 0)} finding(s) need review")
+        for finding in audit.get('items', [])[:3]:
+            lines.append(f"  • {finding.get('severity')}: {finding.get('code')} — {finding.get('reason')}")
+        if audit.get('overflow'):
+            lines.append(f"  • ... and {audit['overflow']} more")
+        lines.append("  Run `tasks.py task-audit`; do not mutate from audit text.")
 
     objective_progress = output.get('objective_progress') or {}
     if objective_progress.get('total_objectives', 0) > 0:

--- a/scripts/standup.py
+++ b/scripts/standup.py
@@ -478,7 +478,11 @@ def generate_standup(
         lines.append("  Review required; do not auto-complete from this summary.")
 
     audit = output.get('task_audit') or {}
-    if audit.get('review_required'):
+    if audit.get('review_required') and not audit.get('available', True):
+        error = audit.get('error') or {}
+        lines.append("")
+        lines.append(f"🧹 **Task Audit:** unavailable ({error.get('code', 'unknown-error')})")
+    elif audit.get('review_required'):
         lines.append("")
         lines.append(f"🧹 **Task Audit:** {audit.get('total', 0)} finding(s) need review")
         for finding in audit.get('items', [])[:3]:

--- a/scripts/task_audit.py
+++ b/scripts/task_audit.py
@@ -279,21 +279,24 @@ def _candidate_findings(
     return findings
 
 
-def _backlog_findings(tasks_file: Path, *, backlog_cap: int | None) -> list[dict[str, Any]]:
+def _backlog_findings(tasks_file: Path, *, backlog_cap: int | None) -> tuple[list[dict[str, Any]], int | None]:
     try:
         audit = audit_items(tasks_file, cap=backlog_cap)
-    except OSError as exc:
-        return [
-            _finding(
-                "backlog-unavailable",
-                "low",
-                "Parking Lot could not be read for backlog audit.",
-                basis={"source": "parking-lot", "error": str(exc)},
-                recommended_action="Inspect the task board path and rerun task-audit.",
-            )
-        ]
+    except (OSError, ValueError) as exc:
+        return (
+            [
+                _finding(
+                    "backlog-unavailable",
+                    "low",
+                    "Parking Lot could not be read for backlog audit.",
+                    basis={"source": "parking-lot", "error": str(exc)},
+                    recommended_action="Inspect task board and parking-lot env configuration, then rerun task-audit.",
+                )
+            ],
+            backlog_cap,
+        )
     if not audit.get("available"):
-        return []
+        return [], audit.get("cap")
 
     findings: list[dict[str, Any]] = []
     cap = audit.get("cap") or 0
@@ -320,7 +323,7 @@ def _backlog_findings(tasks_file: Path, *, backlog_cap: int | None) -> list[dict
                 details=item,
             )
         )
-    return findings
+    return findings, audit.get("cap")
 
 
 def _summary(findings: list[dict[str, Any]], *, limit: int) -> dict[str, Any]:
@@ -370,7 +373,8 @@ def collect_task_audit(
         findings.extend(_due_findings(records, today=today, stale_days=stale_days))
 
     findings.extend(_candidate_findings(personal=personal, today=today, candidate_days=candidate_days))
-    findings.extend(_backlog_findings(tasks_file, backlog_cap=backlog_cap))
+    backlog_findings, effective_backlog_cap = _backlog_findings(tasks_file, backlog_cap=backlog_cap)
+    findings.extend(backlog_findings)
 
     severity_order = {"high": 0, "medium": 1, "low": 2}
     findings = sorted(findings, key=lambda item: (severity_order.get(item.get("severity"), 9), item.get("code", "")))
@@ -383,7 +387,7 @@ def collect_task_audit(
         "thresholds": {
             "stale_days": stale_days,
             "candidate_days": candidate_days,
-            "backlog_cap": backlog_cap,
+            "backlog_cap": effective_backlog_cap,
         },
         "totals": {
             "active_tasks": len(active_records(records)),
@@ -400,7 +404,7 @@ def collect_task_audit(
 def task_audit_summary(*, personal: bool = False, limit: int = 5) -> dict[str, Any]:
     try:
         payload = collect_task_audit(personal=personal, limit=limit)
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
         return {
             "available": False,
             "review_required": True,

--- a/scripts/task_audit.py
+++ b/scripts/task_audit.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import Counter
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -17,6 +18,17 @@ from utils import get_tasks_file
 
 DEFAULT_STALE_DAYS = 14
 DEFAULT_CANDIDATE_DAYS = 7
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _actionable_records(records: list[TaskRecord]) -> list[TaskRecord]:
+    return [record for record in active_records(records) if not record.is_objective]
 
 
 def _parse_date(value: str | None) -> date | None:
@@ -84,11 +96,14 @@ def _finding(
     return finding
 
 
-def _identity_findings(identity: dict[str, Any]) -> list[dict[str, Any]]:
+def _identity_findings(identity: dict[str, Any], records: list[TaskRecord]) -> list[dict[str, Any]]:
     audit = identity.get("audit") or {}
     findings: list[dict[str, Any]] = []
+    objective_lines = {record.line_number for record in records if record.is_objective}
 
     for item in audit.get("malformed_task_ids", []):
+        if item.get("line_number") in objective_lines:
+            continue
         findings.append(
             _finding(
                 "malformed-task-id",
@@ -113,13 +128,15 @@ def _identity_findings(identity: dict[str, Any]) -> list[dict[str, Any]]:
         )
 
     for item in audit.get("missing_task_ids", []):
+        if item.get("line_number") in objective_lines:
+            continue
         findings.append(
             _finding(
                 "missing-task-id",
                 "medium",
                 "Active task is missing canonical task_id:: metadata.",
                 basis={"source": "identity-audit", "line_number": item.get("line_number")},
-                recommended_action="Run identity-repair --dry-run, then identity-repair --apply if the repair is unambiguous.",
+                recommended_action="Run identity-repair, then identity-repair --apply if the repair is unambiguous.",
                 tasks=[item],
             )
         )
@@ -129,7 +146,7 @@ def _identity_findings(identity: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _duplicate_title_findings(records: list[TaskRecord]) -> list[dict[str, Any]]:
     groups: dict[str, list[TaskRecord]] = {}
-    for record in active_records(records):
+    for record in _actionable_records(records):
         groups.setdefault(_normalized_title(record.title), []).append(record)
 
     findings = []
@@ -157,7 +174,7 @@ def _due_findings(
 ) -> list[dict[str, Any]]:
     findings: list[dict[str, Any]] = []
     stale_cutoff = today - timedelta(days=stale_days)
-    for record in active_records(records):
+    for record in _actionable_records(records):
         due_date = _parse_date(record.due)
         if not due_date:
             continue
@@ -220,6 +237,16 @@ def _candidate_findings(
                         for item in exc.malformed
                     ]
                 },
+            )
+        ]
+    except OSError as exc:
+        return [
+            _finding(
+                "candidate-ledger-unavailable",
+                "high",
+                "Candidate ledger could not be read for audit projection.",
+                basis={"source": "completion-candidates", "error": str(exc)},
+                recommended_action="Fix the candidate ledger path before trusting candidate audit output.",
             )
         ]
 
@@ -328,7 +355,8 @@ def _backlog_findings(tasks_file: Path, *, backlog_cap: int | None) -> tuple[lis
 
 def _summary(findings: list[dict[str, Any]], *, limit: int) -> dict[str, Any]:
     severity_counts = Counter(finding.get("severity", "unknown") for finding in findings)
-    top = findings[:limit]
+    effective_limit = max(limit, 0)
+    top = findings[:effective_limit]
     return {
         "review_required": bool(findings),
         "total": len(findings),
@@ -368,7 +396,7 @@ def collect_task_audit(
         )
     else:
         _, _, records = load_records(personal)
-        findings.extend(_identity_findings(identity))
+        findings.extend(_identity_findings(identity, records))
         findings.extend(_duplicate_title_findings(records))
         findings.extend(_due_findings(records, today=today, stale_days=stale_days))
 
@@ -390,7 +418,7 @@ def collect_task_audit(
             "backlog_cap": effective_backlog_cap,
         },
         "totals": {
-            "active_tasks": len(active_records(records)),
+            "active_tasks": len(_actionable_records(records)),
             "findings": len(findings),
             "high": sum(1 for finding in findings if finding.get("severity") == "high"),
             "medium": sum(1 for finding in findings if finding.get("severity") == "medium"),
@@ -403,7 +431,12 @@ def collect_task_audit(
 
 def task_audit_summary(*, personal: bool = False, limit: int = 5) -> dict[str, Any]:
     try:
-        payload = collect_task_audit(personal=personal, limit=limit)
+        payload = collect_task_audit(
+            personal=personal,
+            stale_days=_env_int("TASK_AUDIT_STALE_DAYS", DEFAULT_STALE_DAYS),
+            candidate_days=_env_int("TASK_AUDIT_CANDIDATE_DAYS", DEFAULT_CANDIDATE_DAYS),
+            limit=limit,
+        )
     except (OSError, ValueError) as exc:
         return {
             "available": False,

--- a/scripts/task_audit.py
+++ b/scripts/task_audit.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Read-only task health audits for workflow surfaces."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from completion_candidates import project_candidates
+from parking_lot import audit_items
+from task_identity import audit_payload
+from task_ledger import MalformedLedgerError
+from task_records import TaskRecord, active_records, load_records, record_to_task_dict
+from utils import get_tasks_file
+
+DEFAULT_STALE_DAYS = 14
+DEFAULT_CANDIDATE_DAYS = 7
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _parse_event_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    except ValueError:
+        return _parse_date(value[:10])
+
+
+def _normalized_title(title: str) -> str:
+    return " ".join((title or "").casefold().split())
+
+
+def _safe_task_ref(record: TaskRecord) -> dict[str, Any]:
+    row = record_to_task_dict(record)
+    return {
+        "task_id": row.get("task_id"),
+        "identity_source": row.get("identity_source"),
+        "fallback_id": row.get("fallback_id"),
+        "fallback_only": row.get("fallback_only"),
+        "missing_task_id": row.get("missing_task_id"),
+        "title": row.get("title"),
+        "section": row.get("section"),
+        "area": row.get("area"),
+        "due": row.get("due"),
+        "line_number": row.get("line_number"),
+    }
+
+
+def _finding(
+    code: str,
+    severity: str,
+    reason: str,
+    *,
+    basis: dict[str, Any],
+    recommended_action: str,
+    tasks: list[dict[str, Any]] | None = None,
+    candidate_id: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    finding = {
+        "code": code,
+        "severity": severity,
+        "reason": reason,
+        "basis": basis,
+        "recommended_action": recommended_action,
+    }
+    if tasks is not None:
+        finding["tasks"] = tasks
+    if candidate_id:
+        finding["candidate_id"] = candidate_id
+    if details:
+        finding["details"] = details
+    return finding
+
+
+def _identity_findings(identity: dict[str, Any]) -> list[dict[str, Any]]:
+    audit = identity.get("audit") or {}
+    findings: list[dict[str, Any]] = []
+
+    for item in audit.get("malformed_task_ids", []):
+        findings.append(
+            _finding(
+                "malformed-task-id",
+                "high",
+                "Task line contains malformed task_id metadata.",
+                basis={"source": "identity-audit", "line_number": item.get("line_number")},
+                recommended_action="Run identity-audit, then repair the task line manually.",
+                tasks=[item],
+            )
+        )
+
+    for item in audit.get("duplicate_task_ids", []):
+        findings.append(
+            _finding(
+                "duplicate-task-id",
+                "high",
+                "Multiple active tasks share the same canonical task ID.",
+                basis={"source": "identity-audit", "task_id": item.get("task_id")},
+                recommended_action="Run identity-audit and fix duplicate task_id:: metadata before mutating either task.",
+                tasks=item.get("items") or [],
+            )
+        )
+
+    for item in audit.get("missing_task_ids", []):
+        findings.append(
+            _finding(
+                "missing-task-id",
+                "medium",
+                "Active task is missing canonical task_id:: metadata.",
+                basis={"source": "identity-audit", "line_number": item.get("line_number")},
+                recommended_action="Run identity-repair --dry-run, then identity-repair --apply if the repair is unambiguous.",
+                tasks=[item],
+            )
+        )
+
+    return findings
+
+
+def _duplicate_title_findings(records: list[TaskRecord]) -> list[dict[str, Any]]:
+    groups: dict[str, list[TaskRecord]] = {}
+    for record in active_records(records):
+        groups.setdefault(_normalized_title(record.title), []).append(record)
+
+    findings = []
+    for _, group in sorted(groups.items()):
+        if len(group) < 2:
+            continue
+        findings.append(
+            _finding(
+                "duplicate-title",
+                "medium",
+                "Multiple active tasks have the same title; review before pruning or merging.",
+                basis={"source": "task-records", "match": "normalized-title"},
+                recommended_action="Review the canonical task IDs and decide manually; do not merge or complete by title.",
+                tasks=[_safe_task_ref(record) for record in group],
+            )
+        )
+    return findings
+
+
+def _due_findings(
+    records: list[TaskRecord],
+    *,
+    today: date,
+    stale_days: int,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    stale_cutoff = today - timedelta(days=stale_days)
+    for record in active_records(records):
+        due_date = _parse_date(record.due)
+        if not due_date:
+            continue
+        task = _safe_task_ref(record)
+        if due_date < today:
+            age_days = (today - due_date).days
+            findings.append(
+                _finding(
+                    "overdue-task",
+                    "high" if age_days >= stale_days else "medium",
+                    "Active task is past its due date.",
+                    basis={"source": "task-due-date", "due": record.due, "age_days": age_days},
+                    recommended_action="Review the task by canonical task_id::; carry, postpone, freeze, or complete explicitly.",
+                    tasks=[task],
+                )
+            )
+        if due_date <= stale_cutoff:
+            age_days = (today - due_date).days
+            findings.append(
+                _finding(
+                    "stale-active-task",
+                    "high",
+                    "Active task has been overdue longer than the stale threshold.",
+                    basis={
+                        "source": "task-due-date",
+                        "due": record.due,
+                        "age_days": age_days,
+                        "threshold_days": stale_days,
+                    },
+                    recommended_action="Decide whether to rescope, freeze, backlog, or complete by canonical task_id::.",
+                    tasks=[task],
+                )
+            )
+    return findings
+
+
+def _candidate_findings(
+    *,
+    personal: bool,
+    today: date,
+    candidate_days: int,
+) -> list[dict[str, Any]]:
+    try:
+        candidates = project_candidates(personal=personal)
+    except MalformedLedgerError as exc:
+        return [
+            _finding(
+                "malformed-ledger",
+                "high",
+                "Candidate ledger contains malformed JSONL and cannot be safely projected.",
+                basis={"source": "completion-candidates", "malformed_count": len(exc.malformed)},
+                recommended_action="Fix malformed ledger lines before trusting candidate audit output.",
+                details={
+                    "malformed": [
+                        {
+                            "path": item.path,
+                            "line_number": item.line_number,
+                            "message": item.message,
+                        }
+                        for item in exc.malformed
+                    ]
+                },
+            )
+        ]
+
+    findings: list[dict[str, Any]] = []
+    cutoff = today - timedelta(days=candidate_days)
+    for candidate in candidates:
+        status = candidate.get("status")
+        history = candidate.get("history") or []
+        first_seen = _parse_event_date(history[0].get("timestamp") if history else None)
+        age_days = (today - first_seen).days if first_seen else None
+        if status == "apply_failed":
+            findings.append(
+                _finding(
+                    "candidate-apply-failed",
+                    "high",
+                    "Completion candidate failed to apply and is retryable.",
+                    basis={"source": "candidate-history", "status": status, "age_days": age_days},
+                    recommended_action=f"Inspect candidate {candidate.get('candidate_id')} and retry or reject it explicitly.",
+                    candidate_id=candidate.get("candidate_id"),
+                    details={"summary": candidate.get("summary"), "last_error": candidate.get("last_error")},
+                )
+            )
+            continue
+        if status == "snoozed":
+            snoozed_until = _parse_date(candidate.get("snoozed_until"))
+            if snoozed_until and snoozed_until > today:
+                continue
+            if snoozed_until and snoozed_until <= today:
+                findings.append(
+                    _finding(
+                        "candidate-snooze-expired",
+                        "medium",
+                        "Snoozed completion candidate is actionable again.",
+                        basis={"source": "candidate-history", "snoozed_until": candidate.get("snoozed_until")},
+                        recommended_action=f"Review candidate {candidate.get('candidate_id')}; confirm, reject, duplicate, or snooze.",
+                        candidate_id=candidate.get("candidate_id"),
+                        details={"summary": candidate.get("summary")},
+                    )
+                )
+        if first_seen and first_seen <= cutoff:
+            findings.append(
+                _finding(
+                    "stale-completion-candidate",
+                    "medium",
+                    "Completion candidate has remained unresolved beyond the review threshold.",
+                    basis={
+                        "source": "candidate-history",
+                        "first_seen": first_seen.isoformat(),
+                        "age_days": age_days,
+                        "threshold_days": candidate_days,
+                    },
+                    recommended_action=f"Review candidate {candidate.get('candidate_id')}; confirm only by canonical task_id::.",
+                    candidate_id=candidate.get("candidate_id"),
+                    details={"summary": candidate.get("summary"), "status": status},
+                )
+            )
+    return findings
+
+
+def _backlog_findings(tasks_file: Path, *, backlog_cap: int | None) -> list[dict[str, Any]]:
+    try:
+        audit = audit_items(tasks_file, cap=backlog_cap)
+    except OSError as exc:
+        return [
+            _finding(
+                "backlog-unavailable",
+                "low",
+                "Parking Lot could not be read for backlog audit.",
+                basis={"source": "parking-lot", "error": str(exc)},
+                recommended_action="Inspect the task board path and rerun task-audit.",
+            )
+        ]
+    if not audit.get("available"):
+        return []
+
+    findings: list[dict[str, Any]] = []
+    cap = audit.get("cap") or 0
+    total = audit.get("total") or 0
+    if cap and total >= cap:
+        findings.append(
+            _finding(
+                "backlog-cap-reached",
+                "medium",
+                "Parking Lot is at or above its configured cap.",
+                basis={"source": "parking-lot", "total": total, "cap": cap},
+                recommended_action="Review stale backlog items before adding more.",
+                details={"total": total, "cap": cap},
+            )
+        )
+    for item in audit.get("stale") or []:
+        findings.append(
+            _finding(
+                "stale-backlog-item",
+                "low",
+                "Parking Lot item is older than the stale threshold.",
+                basis={"source": "parking-lot", "created": item.get("created"), "age_days": item.get("age_days")},
+                recommended_action="Review backlog item manually; promote or drop only through explicit backlog commands.",
+                details=item,
+            )
+        )
+    return findings
+
+
+def _summary(findings: list[dict[str, Any]], *, limit: int) -> dict[str, Any]:
+    severity_counts = Counter(finding.get("severity", "unknown") for finding in findings)
+    top = findings[:limit]
+    return {
+        "review_required": bool(findings),
+        "total": len(findings),
+        "by_severity": dict(sorted(severity_counts.items())),
+        "items": top,
+        "overflow": max(0, len(findings) - len(top)),
+        "instructions": "Review audit findings; mutate tasks only through canonical task_id:: commands.",
+    }
+
+
+def collect_task_audit(
+    *,
+    personal: bool = False,
+    stale_days: int = DEFAULT_STALE_DAYS,
+    candidate_days: int = DEFAULT_CANDIDATE_DAYS,
+    backlog_cap: int | None = None,
+    limit: int = 5,
+    today: date | None = None,
+) -> dict[str, Any]:
+    today = today or date.today()
+    tasks_file, _ = get_tasks_file(personal)
+    findings: list[dict[str, Any]] = []
+    records: list[TaskRecord] = []
+
+    identity = audit_payload(personal=personal)
+    error = identity.get("error")
+    if error:
+        findings.append(
+            _finding(
+                "tasks-file-unavailable",
+                "high",
+                "Task board could not be loaded.",
+                basis={"source": "task-board", "path": str(tasks_file)},
+                recommended_action="Fix the task board path before running task automation.",
+                details={"error": error},
+            )
+        )
+    else:
+        _, _, records = load_records(personal)
+        findings.extend(_identity_findings(identity))
+        findings.extend(_duplicate_title_findings(records))
+        findings.extend(_due_findings(records, today=today, stale_days=stale_days))
+
+    findings.extend(_candidate_findings(personal=personal, today=today, candidate_days=candidate_days))
+    findings.extend(_backlog_findings(tasks_file, backlog_cap=backlog_cap))
+
+    severity_order = {"high": 0, "medium": 1, "low": 2}
+    findings = sorted(findings, key=lambda item: (severity_order.get(item.get("severity"), 9), item.get("code", "")))
+
+    return {
+        "ok": not any(finding.get("severity") == "high" for finding in findings),
+        "tasks_file": str(tasks_file),
+        "personal": personal,
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "thresholds": {
+            "stale_days": stale_days,
+            "candidate_days": candidate_days,
+            "backlog_cap": backlog_cap,
+        },
+        "totals": {
+            "active_tasks": len(active_records(records)),
+            "findings": len(findings),
+            "high": sum(1 for finding in findings if finding.get("severity") == "high"),
+            "medium": sum(1 for finding in findings if finding.get("severity") == "medium"),
+            "low": sum(1 for finding in findings if finding.get("severity") == "low"),
+        },
+        "findings": findings,
+        "summary": _summary(findings, limit=limit),
+    }
+
+
+def task_audit_summary(*, personal: bool = False, limit: int = 5) -> dict[str, Any]:
+    try:
+        payload = collect_task_audit(personal=personal, limit=limit)
+    except OSError as exc:
+        return {
+            "available": False,
+            "review_required": True,
+            "error": {"code": "io-error", "message": str(exc)},
+        }
+    summary = payload.get("summary") or {}
+    summary["available"] = True
+    return summary

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -59,6 +59,13 @@ from utils import (
 TASK_PRIMITIVES_SCHEMA_VERSION = "v1"
 
 
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
 def list_tasks(args):
     """List tasks with optional filters."""
     _, tasks_data = load_tasks(args.personal)
@@ -490,8 +497,8 @@ def cmd_task_audit(args):
     payload.update(
         collect_task_audit(
             personal=args.personal,
-            stale_days=args.stale_days,
-            candidate_days=args.candidate_days,
+            stale_days=args.stale_days if args.stale_days is not None else _env_int("TASK_AUDIT_STALE_DAYS", 14),
+            candidate_days=args.candidate_days if args.candidate_days is not None else _env_int("TASK_AUDIT_CANDIDATE_DAYS", 7),
             backlog_cap=args.backlog_cap,
             limit=args.limit,
         )
@@ -1379,13 +1386,13 @@ def main():
     task_audit_parser.add_argument(
         '--stale-days',
         type=int,
-        default=int(os.getenv('TASK_AUDIT_STALE_DAYS', '14')),
+        default=None,
         help='Days overdue before active tasks are flagged stale',
     )
     task_audit_parser.add_argument(
         '--candidate-days',
         type=int,
-        default=int(os.getenv('TASK_AUDIT_CANDIDATE_DAYS', '7')),
+        default=None,
         help='Days before unresolved completion candidates are flagged stale',
     )
     task_audit_parser.add_argument(

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -36,6 +36,7 @@ from evidence_matching import (
 from standup_common import get_calendar_events, flatten_calendar_events
 import delegation
 from task_identity import audit_payload, print_json as print_identity_json
+from task_audit import collect_task_audit, task_audit_summary
 from task_lines import remove_task_line
 from task_repair import repair_missing_ids
 from task_transitions import block_unsafe_query, complete_by_id, print_result
@@ -484,6 +485,20 @@ def cmd_identity_audit(args):
     print_identity_json(audit_payload(personal=args.personal))
 
 
+def cmd_task_audit(args):
+    payload = _new_schema("task-audit")
+    payload.update(
+        collect_task_audit(
+            personal=args.personal,
+            stale_days=args.stale_days,
+            candidate_days=args.candidate_days,
+            backlog_cap=args.backlog_cap,
+            limit=args.limit,
+        )
+    )
+    print(json.dumps(payload, indent=2))
+
+
 def cmd_identity_repair(args):
     payload = repair_missing_ids(personal=args.personal, apply=args.apply)
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -812,6 +827,7 @@ def cmd_standup_summary(args):
             "overdue": overdue,
             "carryover_suggestions": carryover_suggestions,
             "completion_candidates": candidate_review_summary(personal=args.personal),
+            "task_audit": task_audit_summary(personal=args.personal),
             "groups": {
                 "dones_by_area": _group_tasks_by_area(dones),
                 "dos_by_area": _group_tasks_by_area(dos),
@@ -945,6 +961,7 @@ def cmd_weekly_review_summary(args):
                 "by_category": _group_tasks_by_category(do_items),
             },
             "completion_candidates": candidate_review_summary(personal=args.personal),
+            "task_audit": task_audit_summary(personal=args.personal),
         }
     )
     print(json.dumps(payload, indent=2))
@@ -1357,6 +1374,32 @@ def main():
 
     identity_audit_parser = subparsers.add_parser('identity-audit', help='Read-only canonical identity audit')
     identity_audit_parser.set_defaults(func=cmd_identity_audit)
+
+    task_audit_parser = subparsers.add_parser('task-audit', help='Read-only task health audit')
+    task_audit_parser.add_argument(
+        '--stale-days',
+        type=int,
+        default=int(os.getenv('TASK_AUDIT_STALE_DAYS', '14')),
+        help='Days overdue before active tasks are flagged stale',
+    )
+    task_audit_parser.add_argument(
+        '--candidate-days',
+        type=int,
+        default=int(os.getenv('TASK_AUDIT_CANDIDATE_DAYS', '7')),
+        help='Days before unresolved completion candidates are flagged stale',
+    )
+    task_audit_parser.add_argument(
+        '--backlog-cap',
+        type=int,
+        help='Parking Lot cap for backlog pressure checks',
+    )
+    task_audit_parser.add_argument(
+        '--limit',
+        type=int,
+        default=5,
+        help='Maximum findings included in the summary block',
+    )
+    task_audit_parser.set_defaults(func=cmd_task_audit)
 
     identity_repair_parser = subparsers.add_parser('identity-repair', help='Repair missing task_id metadata')
     identity_repair_parser.add_argument('--apply', action='store_true', help='Write safe task_id repairs')

--- a/scripts/weekly_review.py
+++ b/scripts/weekly_review.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from candidate_review import candidate_review_summary
+from task_audit import task_audit_summary
 from daily_notes import extract_completed_actions, extract_completed_tasks
 from task_lines import remove_task_line
 from utils import (
@@ -348,6 +349,27 @@ def append_candidate_review_section(lines: list[str], limit: int = 5) -> None:
     lines.append("  Review required; do not auto-complete from this summary.")
 
 
+def append_task_audit_section(lines: list[str], limit: int = 5) -> None:
+    lines.append("")
+    lines.append("🧹 **Task Audit**")
+    summary = task_audit_summary(limit=limit)
+    if not summary.get("available"):
+        error = summary.get("error") or {}
+        lines.append(f"  Audit unavailable: {error.get('code', 'unknown-error')}.")
+        return
+
+    if not summary.get("total"):
+        lines.append("  No task-health findings.")
+        return
+
+    lines.append(f"  {summary.get('total', 0)} finding(s) need review.")
+    for finding in summary.get("items", []):
+        lines.append(f"  • {finding.get('severity')}: {finding.get('code')} — {finding.get('reason')}")
+    if summary.get("overflow"):
+        lines.append(f"  • ... and {summary['overflow']} more")
+    lines.append("  Run `tasks.py task-audit`; do not mutate from audit text.")
+
+
 def format_overdue(task: dict, reference_date: date) -> str:
     """Return overdue label for a task."""
     due_date = parse_due_date(task.get('due'))
@@ -523,6 +545,7 @@ def generate_weekly_review(week: str | None = None, archive: bool = False) -> st
     lines.extend(velocity_lines)
 
     append_candidate_review_section(lines)
+    append_task_audit_section(lines)
 
     # Archive if requested
     if archive and done_tasks:

--- a/tests/test_task_audit.py
+++ b/tests/test_task_audit.py
@@ -9,7 +9,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 import eod_review
 import standup
-import task_audit
 
 
 def _write_work_file(tmp_path: Path, content: str) -> Path:
@@ -293,7 +292,7 @@ def test_task_audit_excludes_objective_headers_from_actionable_identity_findings
     assert "Send follow-up proposal" in missing_titles
 
 
-def test_task_audit_summary_uses_threshold_env_overrides(monkeypatch, tmp_path):
+def test_task_audit_summary_uses_threshold_env_overrides(tmp_path):
     old_due = (date.today() - timedelta(days=20)).isoformat()
     work = _write_work_file(
         tmp_path,
@@ -303,16 +302,30 @@ def test_task_audit_summary_uses_threshold_env_overrides(monkeypatch, tmp_path):
 - [ ] **Overdue launch task** task_id::tsk_overdue 🗓️{old_due} area:: Delivery
 """,
     )
-    monkeypatch.setenv("TASK_TRACKER_WORK_FILE", str(work))
-    monkeypatch.setenv("TASK_TRACKER_DAILY_NOTES_DIR", str(tmp_path / "daily"))
-    monkeypatch.setenv("TASK_TRACKER_DONE_LOG_DIR", str(tmp_path / "daily"))
-    monkeypatch.setenv("TASK_TRACKER_LEDGER_FILE", str(tmp_path / "events.jsonl"))
-    monkeypatch.setenv("TASK_AUDIT_STALE_DAYS", "30")
-    monkeypatch.setenv("TASK_AUDIT_CANDIDATE_DAYS", "11")
+    env = _env(tmp_path, work)
+    env["TASK_AUDIT_STALE_DAYS"] = "30"
+    env["TASK_AUDIT_CANDIDATE_DAYS"] = "11"
 
-    summary = task_audit.task_audit_summary(limit=10)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys; "
+                "sys.path.insert(0, 'scripts'); "
+                "import task_audit; "
+                "print(json.dumps(task_audit.task_audit_summary(limit=10)))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    summary = json.loads(proc.stdout)
     codes = {item["code"] for item in summary["items"]}
 
+    assert proc.returncode == 0
     assert summary["available"] is True
     assert "overdue-task" in codes
     assert "stale-active-task" not in codes

--- a/tests/test_task_audit.py
+++ b/tests/test_task_audit.py
@@ -1,8 +1,14 @@
 import json
 import os
 import subprocess
+import sys
 from datetime import date, timedelta
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import eod_review
+import standup
 
 
 def _write_work_file(tmp_path: Path, content: str) -> Path:
@@ -70,6 +76,117 @@ def test_task_audit_reports_duplicate_missing_overdue_and_backlog_without_mutati
     assert "stale-active-task" in codes
     assert "stale-backlog-item" in codes
     assert work.read_text() == original
+
+
+def test_invalid_task_audit_env_defaults_do_not_break_other_commands(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    env["TASK_AUDIT_STALE_DAYS"] = "not-a-number"
+    env["TASK_AUDIT_CANDIDATE_DAYS"] = "also-bad"
+
+    listed = _run(["list"], env)
+    audit = _run(["task-audit"], env)
+    payload = _payload(audit)
+
+    assert listed.returncode == 0
+    assert audit.returncode == 0
+    assert payload["thresholds"]["stale_days"] == 14
+    assert payload["thresholds"]["candidate_days"] == 7
+
+
+def test_task_audit_reports_effective_default_backlog_cap(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+
+## 🅿️ Parking Lot
+- [ ] **Idea one** task_id::tsk_idea created::2026-01-01 #Dev #low
+""",
+    )
+    env = _env(tmp_path, work)
+    env["PARKING_LOT_CAP"] = "1"
+
+    proc = _run(["task-audit"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["thresholds"]["backlog_cap"] == 1
+    assert "backlog-cap-reached" in {finding["code"] for finding in payload["findings"]}
+
+
+def test_task_audit_degrades_on_invalid_parking_lot_env(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+
+## 🅿️ Parking Lot
+- [ ] **Idea one** task_id::tsk_idea created::2026-01-01 #Dev #low
+""",
+    )
+    env = _env(tmp_path, work)
+    env["PARKING_LOT_CAP"] = "bad-cap"
+
+    proc = _run(["task-audit"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert "backlog-unavailable" in {finding["code"] for finding in payload["findings"]}
+
+
+def test_standup_and_eod_render_unavailable_audit_as_error(monkeypatch):
+    unavailable = {
+        "available": False,
+        "review_required": True,
+        "error": {"code": "io-error", "message": "cannot read board"},
+    }
+
+    monkeypatch.setattr(standup, "task_audit_summary", lambda limit=3: unavailable)
+    monkeypatch.setattr(standup, "candidate_review_summary", lambda: {})
+    monkeypatch.setattr(standup, "get_calendar_events", lambda: {})
+    standup_text = standup.generate_standup(
+        date_str="2026-05-22",
+        tasks_data={"q1": [], "q2": [], "q3": [], "team": [], "done": [], "due_today": [], "all": []},
+    )
+    eod_text = eod_review.format_markdown(
+        {
+            "weekday": "Friday",
+            "date": "2026-05-22",
+            "source": "test",
+            "done": [],
+            "not_done": [],
+            "tomorrows_top3": [],
+            "completion_candidates": {},
+            "task_audit": unavailable,
+        }
+    )
+    eod_telegram = eod_review.format_telegram(
+        {
+            "weekday": "Friday",
+            "date": "2026-05-22",
+            "done": [],
+            "not_done": [],
+            "tomorrows_top3": [],
+            "completion_candidates": {},
+            "task_audit": unavailable,
+        }
+    )
+
+    assert "unavailable (io-error)" in standup_text
+    assert "Audit unavailable: io-error." in eod_text
+    assert "Unavailable: io-error" in eod_telegram
 
 
 def test_task_audit_reports_stale_candidates_and_does_not_write_ledger(tmp_path):

--- a/tests/test_task_audit.py
+++ b/tests/test_task_audit.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 import eod_review
 import standup
+import task_audit
 
 
 def _write_work_file(tmp_path: Path, content: str) -> Path:
@@ -237,6 +238,104 @@ def test_task_audit_degrades_on_malformed_ledger_but_keeps_identity_findings(tmp
     assert proc.returncode == 0
     assert "malformed-ledger" in codes
     assert "missing-task-id" in codes
+
+
+def test_task_audit_degrades_on_unreadable_candidate_ledger(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Missing id task** area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    ledger_dir = tmp_path / "events-as-dir"
+    ledger_dir.mkdir()
+    env["TASK_TRACKER_LEDGER_FILE"] = str(ledger_dir)
+
+    proc = _run(["task-audit"], env)
+    payload = _payload(proc)
+    codes = {finding["code"] for finding in payload["findings"]}
+
+    assert proc.returncode == 0
+    assert "candidate-ledger-unavailable" in codes
+    assert "missing-task-id" in codes
+
+
+def test_task_audit_excludes_objective_headers_from_actionable_identity_findings(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## Objectives
+- [ ] Launch hiring plan #HR #high
+  - [ ] Post on LinkedIn task_id::tsk_post_linkedin
+- [ ] Close Fizzi deal #Sales #urgent
+  - [ ] Send follow-up proposal
+""",
+    )
+    env = _env(tmp_path, work)
+
+    proc = _run(["task-audit"], env)
+    payload = _payload(proc)
+    missing = [finding for finding in payload["findings"] if finding["code"] == "missing-task-id"]
+    missing_titles = {
+        task["title"]
+        for finding in missing
+        for task in finding.get("tasks", [])
+    }
+
+    assert proc.returncode == 0
+    assert payload["totals"]["active_tasks"] == 2
+    assert "Launch hiring plan" not in missing_titles
+    assert "Close Fizzi deal" not in missing_titles
+    assert "Send follow-up proposal" in missing_titles
+
+
+def test_task_audit_summary_uses_threshold_env_overrides(monkeypatch, tmp_path):
+    old_due = (date.today() - timedelta(days=20)).isoformat()
+    work = _write_work_file(
+        tmp_path,
+        f"""# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Overdue launch task** task_id::tsk_overdue 🗓️{old_due} area:: Delivery
+""",
+    )
+    monkeypatch.setenv("TASK_TRACKER_WORK_FILE", str(work))
+    monkeypatch.setenv("TASK_TRACKER_DAILY_NOTES_DIR", str(tmp_path / "daily"))
+    monkeypatch.setenv("TASK_TRACKER_DONE_LOG_DIR", str(tmp_path / "daily"))
+    monkeypatch.setenv("TASK_TRACKER_LEDGER_FILE", str(tmp_path / "events.jsonl"))
+    monkeypatch.setenv("TASK_AUDIT_STALE_DAYS", "30")
+    monkeypatch.setenv("TASK_AUDIT_CANDIDATE_DAYS", "11")
+
+    summary = task_audit.task_audit_summary(limit=10)
+    codes = {item["code"] for item in summary["items"]}
+
+    assert summary["available"] is True
+    assert "overdue-task" in codes
+    assert "stale-active-task" not in codes
+
+
+def test_task_audit_negative_summary_limit_does_not_slice_from_tail(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Missing id task** area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+
+    proc = _run(["task-audit", "--limit", "-1"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["summary"]["total"] >= 1
+    assert payload["summary"]["items"] == []
+    assert payload["summary"]["overflow"] == payload["summary"]["total"]
 
 
 def test_task_audit_does_not_flag_future_snoozed_candidate_stale(tmp_path):

--- a/tests/test_task_audit.py
+++ b/tests/test_task_audit.py
@@ -1,0 +1,185 @@
+import json
+import os
+import subprocess
+from datetime import date, timedelta
+from pathlib import Path
+
+
+def _write_work_file(tmp_path: Path, content: str) -> Path:
+    work = tmp_path / "Weekly TODOs.md"
+    work.write_text(content)
+    return work
+
+
+def _env(tmp_path: Path, work: Path) -> dict:
+    env = os.environ.copy()
+    env["TASK_TRACKER_WORK_FILE"] = str(work)
+    env["TASK_TRACKER_DAILY_NOTES_DIR"] = str(tmp_path / "daily")
+    env["TASK_TRACKER_DONE_LOG_DIR"] = str(tmp_path / "daily")
+    env["TASK_TRACKER_LEDGER_FILE"] = str(tmp_path / "events.jsonl")
+    env["STANDUP_CALENDARS"] = "{}"
+    return env
+
+
+def _run(args: list[str], env: dict, *, input_text: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python3", "scripts/tasks.py", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _payload(proc: subprocess.CompletedProcess) -> dict:
+    assert "Traceback" not in proc.stdout
+    assert "Traceback" not in proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_task_audit_reports_duplicate_missing_overdue_and_backlog_without_mutation(tmp_path):
+    old_due = (date.today() - timedelta(days=20)).isoformat()
+    old_created = (date.today() - timedelta(days=45)).isoformat()
+    work = _write_work_file(
+        tmp_path,
+        f"""# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Duplicate title** task_id::tsk_one area:: Delivery
+- [ ] **Duplicate title** area:: Platform
+- [ ] **Overdue launch task** task_id::tsk_overdue 🗓️{old_due} area:: Delivery
+
+## 🅿️ Parking Lot
+- [ ] **Old backlog idea** task_id::tsk_backlog created::{old_created} #Dev #low
+""",
+    )
+    original = work.read_text()
+    env = _env(tmp_path, work)
+
+    proc = _run(["task-audit", "--stale-days", "14", "--candidate-days", "7"], env)
+    payload = _payload(proc)
+    codes = {finding["code"] for finding in payload["findings"]}
+
+    assert proc.returncode == 0
+    assert payload["schema_version"] == "v1"
+    assert payload["command"] == "task-audit"
+    assert "duplicate-title" in codes
+    assert "missing-task-id" in codes
+    assert "overdue-task" in codes
+    assert "stale-active-task" in codes
+    assert "stale-backlog-item" in codes
+    assert work.read_text() == original
+
+
+def test_task_audit_reports_stale_candidates_and_does_not_write_ledger(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    scan = _run(["completion-candidates", "scan"], env, input_text="- Ship alpha milestone task_id::tsk_ship\n")
+    scan_payload = _payload(scan)
+    assert scan.returncode == 0
+    assert scan_payload["created"]
+
+    ledger = tmp_path / "events.jsonl"
+    event = json.loads(ledger.read_text().strip())
+    event["timestamp"] = (date.today() - timedelta(days=10)).isoformat()
+    ledger.write_text(json.dumps(event) + "\n")
+    before = ledger.read_text()
+
+    proc = _run(["task-audit", "--candidate-days", "7"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert "stale-completion-candidate" in {finding["code"] for finding in payload["findings"]}
+    assert ledger.read_text() == before
+
+
+def test_task_audit_degrades_on_malformed_ledger_but_keeps_identity_findings(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Missing id task** area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    (tmp_path / "events.jsonl").write_text("{bad-json\n")
+
+    proc = _run(["task-audit"], env)
+    payload = _payload(proc)
+    codes = {finding["code"] for finding in payload["findings"]}
+
+    assert proc.returncode == 0
+    assert "malformed-ledger" in codes
+    assert "missing-task-id" in codes
+
+
+def test_task_audit_does_not_flag_future_snoozed_candidate_stale(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Weekly TODOs
+
+## 🔴 Q1
+- [ ] **Ship alpha milestone** task_id::tsk_ship area:: Delivery
+""",
+    )
+    env = _env(tmp_path, work)
+    scan = _run(
+        ["completion-candidates", "scan"],
+        env,
+        input_text="- Ship alpha milestone task_id::tsk_ship\n",
+    )
+    candidate_id = _payload(scan)["created"][0]["candidate_id"]
+    future = (date.today() + timedelta(days=7)).isoformat()
+    snooze = _run(["completion-candidates", "snooze", candidate_id, "--until", future], env)
+    assert snooze.returncode == 0
+
+    ledger = tmp_path / "events.jsonl"
+    events = [json.loads(line) for line in ledger.read_text().splitlines()]
+    events[0]["timestamp"] = (date.today() - timedelta(days=30)).isoformat()
+    ledger.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+
+    proc = _run(["task-audit", "--candidate-days", "7"], env)
+    codes = {finding["code"] for finding in _payload(proc)["findings"]}
+
+    assert proc.returncode == 0
+    assert "stale-completion-candidate" not in codes
+    assert "candidate-snooze-expired" not in codes
+
+
+def test_task_audit_personal_uses_personal_files_and_ledger(tmp_path):
+    work = _write_work_file(
+        tmp_path,
+        """# Work
+
+## 🔴 Q1
+- [ ] **Work task** task_id::tsk_work
+""",
+    )
+    personal = tmp_path / "Personal Tasks.md"
+    personal.write_text(
+        """# Personal
+
+## 🔴 Q1
+- [ ] **Personal task** area:: Home
+"""
+    )
+    env = _env(tmp_path, work)
+    env["TASK_TRACKER_PERSONAL_FILE"] = str(personal)
+
+    proc = _run(["--personal", "task-audit"], env)
+    payload = _payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["personal"] is True
+    assert payload["tasks_file"] == str(personal)
+    assert payload["totals"]["active_tasks"] == 1
+    assert "missing-task-id" in {finding["code"] for finding in payload["findings"]}

--- a/tests/test_task_primitives.py
+++ b/tests/test_task_primitives.py
@@ -78,6 +78,7 @@ def test_primitive_schema_shape(tmp_path):
     assert "overdue" in standup_payload
     assert "carryover_suggestions" in standup_payload
     assert "completion_candidates" in standup_payload
+    assert "task_audit" in standup_payload
 
     week_start = date.today() - timedelta(days=date.today().weekday())
     week_end = week_start + timedelta(days=6)
@@ -105,6 +106,21 @@ def test_primitive_schema_shape(tmp_path):
     assert "by_area" in weekly_payload["DONE"]
     assert "by_category" in weekly_payload["DO"]
     assert "completion_candidates" in weekly_payload
+    assert "task_audit" in weekly_payload
+
+    audit = subprocess.run(
+        ["python3", "scripts/tasks.py", "task-audit"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert audit.returncode == 0
+    audit_payload = json.loads(audit.stdout)
+    assert audit_payload["schema_version"] == "v1"
+    assert audit_payload["command"] == "task-audit"
+    assert "findings" in audit_payload
+    assert "summary" in audit_payload
 
     cal = subprocess.run(
         ["python3", "scripts/tasks.py", "calendar-sync"],


### PR DESCRIPTION
## Summary

Task tracker now has a read-only periodic audit layer that surfaces task-system buildup before it pollutes standup and weekly review. The audit reports duplicate titles, missing or malformed identities, overdue/stale tasks, unresolved completion candidates, and backlog pressure while preserving the current source-of-truth rule: active boards own task state, and mutations still require explicit canonical IDs.

## Design decisions

- Added `tasks.py task-audit` as the stable primitive so workflows can consume one JSON contract instead of parsing markdown directly.
- Kept all audit findings advisory: recommendations point to safe existing commands, and the audit never freezes, deletes, merges, completes, or writes ledger state.
- Reused existing identity, `TaskRecord`, completion-candidate, and parking-lot surfaces instead of creating a second task model.
- Added capped audit summaries to standup, EOD, and weekly review so daily surfaces stay concise and link back to the full audit command for detail.

## Size note

[size/exempt: this includes a durable plan artifact plus first-version audit collector and regression coverage; the behavioral code is scoped to one primitive and its read-only workflow summaries.]

## Verification

- `python3 -m py_compile scripts/task_audit.py scripts/tasks.py scripts/standup.py scripts/eod_review.py scripts/weekly_review.py scripts/parking_lot.py`
- `python3 -m pytest -q` -> 191 passed
- `markdownlint README.md SKILL.md references/commands.md references/task-primitives-schema-v1.md docs/plans/2026-05-21-004-feat-inbox-workflow-consumption-plan.md docs/plans/2026-05-22-001-feat-periodic-task-audits-plan.md`
- `git diff --check`
- `bash scripts/ci/check-public-hygiene.sh`

## Browser testing

No browser routes are affected; this repo change is CLI/docs/tests only. `agent-browser` is installed, but there is no dev-server route to exercise for this diff.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
